### PR TITLE
Conditionally compile sensors

### DIFF
--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -131,6 +131,7 @@ namespace esphome::luxtronik_v1
     Luxtronik::Luxtronik(uart::UARTComponent* uart)
         : PollingComponent()
         , m_device(uart)
+#ifdef USE_SENSOR
         , m_sensor_flow_temperature(nullptr)
         , m_sensor_return_temperature(nullptr)
         , m_sensor_return_set_temperature(nullptr)
@@ -143,6 +144,8 @@ namespace esphome::luxtronik_v1
         , m_sensor_mixed_circuit_1_temperature(nullptr)
         , m_sensor_mixed_circuit_1_set_temperature(nullptr)
         , m_sensor_remote_adjuster_temperature(nullptr)
+#endif
+#ifdef USE_BINARY_SENSOR
         , m_sensor_defrost_brine_flow(nullptr)
         , m_sensor_power_provider_lock_period(nullptr)
         , m_sensor_high_pressure_state(nullptr)
@@ -153,7 +156,6 @@ namespace esphome::luxtronik_v1
         , m_sensor_hot_water_pump(nullptr)
         , m_sensor_floor_heating_pump(nullptr)
         , m_sensor_heating_pump(nullptr)
-        , m_sensor_mixer_1_state(nullptr)
         , m_sensor_housing_ventilation(nullptr)
         , m_sensor_ventilation_pump(nullptr)
         , m_sensor_compressor_1(nullptr)
@@ -161,6 +163,10 @@ namespace esphome::luxtronik_v1
         , m_sensor_extra_pump(nullptr)
         , m_sensor_secondary_heater_1(nullptr)
         , m_sensor_secondary_heater_2_failure(nullptr)
+        , m_sensor_device_communication(nullptr)
+#endif
+#ifdef USE_TEXT_SENSOR
+        , m_sensor_mixer_1_state(nullptr)
         , m_sensor_device_type(nullptr)
         , m_sensor_firmware_version(nullptr)
         , m_sensor_bivalence_level(nullptr)
@@ -187,7 +193,7 @@ namespace esphome::luxtronik_v1
         , m_sensor_deactivation_3_time(nullptr)
         , m_sensor_deactivation_4_time(nullptr)
         , m_sensor_deactivation_5_time(nullptr)
-        , m_sensor_device_communication(nullptr)
+#endif
         , m_response_buffer{}
         , m_cursor(0)
         , m_received_responses(RESPONSE_ALL)
@@ -259,10 +265,12 @@ namespace esphome::luxtronik_v1
             ESP_LOGW(TAG, "No full response from Luxtronik in last update cycle:  RESP %04X", m_received_responses);
         }
 
+#ifdef USE_BINARY_SENSOR
         if (m_sensor_device_communication != nullptr)
         {
             m_sensor_device_communication->publish_state(m_received_responses != RESPONSE_ALL);
         }
+#endif
 
         m_received_responses = RESPONSE_NONE;
         m_slot_block = false;
@@ -278,6 +286,7 @@ namespace esphome::luxtronik_v1
     {
         ESP_LOGCONFIG(TAG, "Luxtronik V1");
 
+#ifdef USE_SENSOR
         LOG_SENSOR("", "Flow Temperture Sensor", m_sensor_flow_temperature);
         LOG_SENSOR("", "Return Temperture Sensor", m_sensor_return_temperature);
         LOG_SENSOR("", "Return Set-Temperture Sensor", m_sensor_return_set_temperature);
@@ -290,7 +299,9 @@ namespace esphome::luxtronik_v1
         LOG_SENSOR("", "Mixed Circuit 1 Temperture Sensor", m_sensor_mixed_circuit_1_temperature);
         LOG_SENSOR("", "Mixed Circuit 1 Set-Temperture Sensor", m_sensor_mixed_circuit_1_set_temperature);
         LOG_SENSOR("", "Remote Adjuster Temperture Sensor", m_sensor_remote_adjuster_temperature);
+#endif
 
+#ifdef USE_BINARY_SENSOR
         LOG_BINARY_SENSOR("", "Defrost/Brine/Flow Sensor", m_sensor_defrost_brine_flow);
         LOG_BINARY_SENSOR("", "Power Provider Lock Period Sensor", m_sensor_power_provider_lock_period);
         LOG_BINARY_SENSOR("", "Low Pressure State Sensor", m_sensor_low_pressure_state);
@@ -308,7 +319,10 @@ namespace esphome::luxtronik_v1
         LOG_BINARY_SENSOR("", "Extra Pump Sensor", m_sensor_extra_pump);
         LOG_BINARY_SENSOR("", "Secondary Heater 1 Sensor", m_sensor_secondary_heater_1);
         LOG_BINARY_SENSOR("", "Secondary Heater 2 Failure Sensor", m_sensor_secondary_heater_2_failure);
+        LOG_BINARY_SENSOR("", "Device Communication Sensor", m_sensor_device_communication);
+#endif
 
+#ifdef USE_TEXT_SENSOR
         LOG_TEXT_SENSOR("", "Mixer 1 Sensor", m_sensor_mixer_1_state);
         LOG_TEXT_SENSOR("", "Device Type Sensor", m_sensor_device_type);
         LOG_TEXT_SENSOR("", "Firmware Version Sensor", m_sensor_firmware_version);
@@ -334,6 +348,7 @@ namespace esphome::luxtronik_v1
         LOG_TEXT_SENSOR("", "Deactivation 3 Time Sensor", m_sensor_deactivation_3_time);
         LOG_TEXT_SENSOR("", "Deactivation 4 Time Sensor", m_sensor_deactivation_4_time);
         LOG_TEXT_SENSOR("", "Deactivation 5 Time Sensor", m_sensor_deactivation_5_code);
+#endif
     }
 
     void Luxtronik::send_request(const char* request)
@@ -362,6 +377,7 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_flow_temperature != nullptr)
             {
                 m_sensor_flow_temperature->
@@ -369,9 +385,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_return_temperature != nullptr)
             {
                 m_sensor_return_temperature->
@@ -379,9 +397,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_return_set_temperature != nullptr)
             {
                 m_sensor_return_set_temperature->
@@ -389,9 +409,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_hot_gas_temperature != nullptr)
             {
                 m_sensor_hot_gas_temperature->
@@ -399,9 +421,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_outside_temperature != nullptr)
             {
                 m_sensor_outside_temperature->
@@ -409,9 +433,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_hot_water_temperature != nullptr)
             {
                 m_sensor_hot_water_temperature->
@@ -419,9 +445,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_hot_water_set_temperature != nullptr)
             {
                 m_sensor_hot_water_set_temperature->
@@ -429,9 +457,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_heat_source_input_temperature != nullptr)
             {
                 m_sensor_heat_source_input_temperature->
@@ -439,9 +469,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_heat_source_output_temperature != nullptr)
             {
                 m_sensor_heat_source_output_temperature->
@@ -449,9 +481,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_mixed_circuit_1_temperature != nullptr)
             {
                 m_sensor_mixed_circuit_1_temperature->
@@ -459,9 +493,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_mixed_circuit_1_set_temperature != nullptr)
             {
                 m_sensor_mixed_circuit_1_set_temperature->
@@ -469,9 +505,11 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_SENSOR
             if (m_sensor_remote_adjuster_temperature != nullptr)
             {
                 m_sensor_remote_adjuster_temperature->
@@ -479,6 +517,7 @@ namespace esphome::luxtronik_v1
                         get_temperature(
                             response.substr(start, end - start)));
             }
+#endif
 
             m_received_responses |= RESPONSE_TEMPERATURES;
 
@@ -493,6 +532,7 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_defrost_brine_flow != nullptr)
             {
                 m_sensor_defrost_brine_flow->
@@ -500,9 +540,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(  // on = defrost ending or flow rate ok (depending on device type)
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_power_provider_lock_period != nullptr)
             {
                 m_sensor_power_provider_lock_period->
@@ -510,9 +552,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(  // off = lock period, on = not locked
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_high_pressure_state != nullptr)
             {
                 m_sensor_high_pressure_state->
@@ -520,9 +564,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(  // off = pressure ok, on = not ok
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_engine_protection != nullptr)
             {
                 m_sensor_engine_protection->
@@ -530,9 +576,11 @@ namespace esphome::luxtronik_v1
                         !get_binary_state(  // on = engine protection ok, off = not ok
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_low_pressure_state != nullptr)
             {
                 m_sensor_low_pressure_state->
@@ -540,9 +588,11 @@ namespace esphome::luxtronik_v1
                         !get_binary_state(  // on = pressure ok, off = not ok
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_external_power != nullptr)
             {
                 m_sensor_external_power->
@@ -550,6 +600,7 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             m_received_responses |= RESPONSE_INPUTS;
 
@@ -564,6 +615,7 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_defrost_valve != nullptr)
             {
                 m_sensor_defrost_valve->
@@ -571,9 +623,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_hot_water_pump != nullptr)
             {
                 m_sensor_hot_water_pump->
@@ -581,9 +635,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_floor_heating_pump != nullptr)
             {
                 m_sensor_floor_heating_pump->
@@ -591,9 +647,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_heating_pump != nullptr)
             {
                 m_sensor_heating_pump->
@@ -601,6 +659,7 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
@@ -610,6 +669,7 @@ namespace esphome::luxtronik_v1
             end = response.find(DELIMITER, start);
             bool mixerClose = get_binary_state(response.substr(start, end - start));
 
+#ifdef USE_TEXT_SENSOR
             // merge the two separate states (Mischer 1 fährt auf, Mischer 1 fährt zu) into one sensor
             if (m_sensor_mixer_1_state != nullptr)
             {
@@ -621,9 +681,11 @@ namespace esphome::luxtronik_v1
                                 ? "closing"
                                 : "idle");
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_housing_ventilation != nullptr)
             {
                 m_sensor_housing_ventilation->
@@ -631,9 +693,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_ventilation_pump != nullptr)
             {
                 m_sensor_ventilation_pump->
@@ -641,9 +705,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_compressor_1 != nullptr)
             {
                 m_sensor_compressor_1->
@@ -651,9 +717,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_compressor_2 != nullptr)
             {
                 m_sensor_compressor_2->
@@ -661,9 +729,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_extra_pump != nullptr)
             {
                 m_sensor_extra_pump->
@@ -671,9 +741,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_secondary_heater_1 != nullptr)
             {
                 m_sensor_secondary_heater_1->
@@ -681,9 +753,11 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_BINARY_SENSOR
             if (m_sensor_secondary_heater_2_failure != nullptr)
             {
                 m_sensor_secondary_heater_2_failure->
@@ -691,6 +765,7 @@ namespace esphome::luxtronik_v1
                         get_binary_state(
                             response.substr(start, end - start)));
             }
+#endif
 
             m_received_responses |= RESPONSE_OUTPUTS;
 
@@ -705,6 +780,7 @@ namespace esphome::luxtronik_v1
 
             if (starts_with(slot, TYPE_ERRORS_SLOT) && (response.length() >= MIN_SLOT_LENGTH))
             {
+#ifdef USE_TEXT_SENSOR
                 char slotID = response.at(INDEX_SLOT_ID);
                 switch (slotID)
                 {
@@ -714,6 +790,7 @@ namespace esphome::luxtronik_v1
                     case SLOT_4_ID: { parse_slot(response.substr(10), m_sensor_error_4_code, m_sensor_error_4_time); break; }
                     case SLOT_5_ID: { parse_slot(response.substr(10), m_sensor_error_5_code, m_sensor_error_5_time); break; }
                 }
+#endif
             }
             else if (!m_slot_block)
             {
@@ -736,6 +813,7 @@ namespace esphome::luxtronik_v1
 
             if (starts_with(slot, TYPE_DEACTIVATIONS_SLOT) && (response.length() >= MIN_SLOT_LENGTH))
             {
+#ifdef USE_TEXT_SENSOR
                 char slotID = response.at(INDEX_SLOT_ID);
                 switch (slotID)
                 {
@@ -745,6 +823,7 @@ namespace esphome::luxtronik_v1
                     case SLOT_4_ID: { parse_slot(response.substr(10), m_sensor_deactivation_4_code, m_sensor_deactivation_4_time); break; }
                     case SLOT_5_ID: { parse_slot(response.substr(10), m_sensor_deactivation_5_code, m_sensor_deactivation_5_time); break; }
                 }
+#endif
             }
             else if (!m_slot_block)
             {
@@ -769,6 +848,7 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_TEXT_SENSOR
             if (m_sensor_device_type != nullptr)
             {
                 value = std::atoi(response.substr(start, end - start).c_str());
@@ -793,9 +873,11 @@ namespace esphome::luxtronik_v1
                 }
                 m_sensor_device_type->publish_state(text);
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_TEXT_SENSOR
             if (m_sensor_firmware_version != nullptr)
             {
                 m_sensor_firmware_version->
@@ -804,9 +886,11 @@ namespace esphome::luxtronik_v1
                             start + 1,  // version without 'V' prefix
                             end - start - 1));
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_TEXT_SENSOR
             if (m_sensor_bivalence_level != nullptr)
             {
                 value = std::atoi(response.substr(start, end - start).c_str());
@@ -819,9 +903,11 @@ namespace esphome::luxtronik_v1
                 }
                 m_sensor_bivalence_level->publish_state(text);
             }
+#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_TEXT_SENSOR
             if (m_sensor_operational_state != nullptr)
             {
                 value = std::atoi(response.substr(start, end - start).c_str());
@@ -837,6 +923,7 @@ namespace esphome::luxtronik_v1
                 }
                 m_sensor_operational_state->publish_state(text);
             }
+#endif
 
             m_received_responses |= RESPONSE_INFORMATION;
 
@@ -853,6 +940,7 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_TEXT_SENSOR
             if (m_sensor_heating_mode != nullptr)
             {
                 value = std::atoi(response.substr(start, end - start).c_str());
@@ -867,6 +955,7 @@ namespace esphome::luxtronik_v1
                 }
                 m_sensor_heating_mode->publish_state(text);
             }
+#endif
 
             m_received_responses |= RESPONSE_HEATING_MODE;
 
@@ -883,6 +972,7 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
+#ifdef USE_TEXT_SENSOR
             if (m_sensor_hot_water_mode != nullptr)
             {
                 value = std::atoi(response.substr(start, end - start).c_str());
@@ -897,11 +987,13 @@ namespace esphome::luxtronik_v1
                 }
                 m_sensor_hot_water_mode->publish_state(text);
             }
+#endif
 
             m_received_responses |= RESPONSE_HOT_WATER_MODE;
         }
     }
 
+#ifdef USE_TEXT_SENSOR
     void Luxtronik::parse_slot(const std::string& slot, text_sensor::TextSensor* sensor_code, text_sensor::TextSensor* sensor_time)
     {
         size_t start = 0;
@@ -950,4 +1042,5 @@ namespace esphome::luxtronik_v1
             sensor_time->publish_state(timeStr);
         }
     }
+#endif
 }  // namespace esphome::luxtronik_v1

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -25,10 +25,17 @@
 
 #pragma once
 
+#include "esphome/core/defines.h"
 #include "esphome/core/component.h"
+#ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
 #include "esphome/components/text_sensor/text_sensor.h"
+#endif
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/hal.h"
 
@@ -48,6 +55,7 @@ namespace esphome::luxtronik_v1
 
         void dump_config() override;
 
+#ifdef USE_SENSOR
         void set_sensor_flow_temperature(sensor::Sensor* sensor)                        { m_sensor_flow_temperature                = sensor; }
         void set_sensor_return_temperature(sensor::Sensor* sensor)                      { m_sensor_return_temperature              = sensor; }
         void set_sensor_return_set_temperature(sensor::Sensor* sensor)                  { m_sensor_return_set_temperature          = sensor; }
@@ -60,6 +68,8 @@ namespace esphome::luxtronik_v1
         void set_sensor_mixed_circuit_1_temperature(sensor::Sensor* sensor)             { m_sensor_mixed_circuit_1_temperature     = sensor; }
         void set_sensor_mixed_circuit_1_set_temperature(sensor::Sensor* sensor)         { m_sensor_mixed_circuit_1_set_temperature = sensor; }
         void set_sensor_remote_adjuster_temperature(sensor::Sensor* sensor)             { m_sensor_remote_adjuster_temperature     = sensor; }
+#endif
+#ifdef USE_BINARY_SENSOR
         void set_sensor_defrost_brine_flow(binary_sensor::BinarySensor* sensor)         { m_sensor_defrost_brine_flow              = sensor; }
         void set_sensor_power_provider_lock_period(binary_sensor::BinarySensor* sensor) { m_sensor_power_provider_lock_period      = sensor; }
         void set_sensor_high_pressure_state(binary_sensor::BinarySensor* sensor)        { m_sensor_high_pressure_state             = sensor; }
@@ -77,6 +87,9 @@ namespace esphome::luxtronik_v1
         void set_sensor_extra_pump(binary_sensor::BinarySensor* sensor)                 { m_sensor_extra_pump                      = sensor; }
         void set_sensor_secondary_heater_1(binary_sensor::BinarySensor* sensor)         { m_sensor_secondary_heater_1              = sensor; }
         void set_sensor_secondary_heater_2_failure(binary_sensor::BinarySensor* sensor) { m_sensor_secondary_heater_2_failure      = sensor; }
+        void set_sensor_device_communication(binary_sensor::BinarySensor* sensor)       { m_sensor_device_communication            = sensor; }
+#endif
+#ifdef USE_TEXT_SENSOR
         void set_sensor_mixer_1_state(text_sensor::TextSensor* sensor)                  { m_sensor_mixer_1_state                   = sensor; }
         void set_sensor_device_type(text_sensor::TextSensor* sensor)                    { m_sensor_device_type                     = sensor; }
         void set_sensor_firmware_version(text_sensor::TextSensor* sensor)               { m_sensor_firmware_version                = sensor; }
@@ -104,12 +117,14 @@ namespace esphome::luxtronik_v1
         void set_sensor_deactivation_3_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_time             = sensor; }
         void set_sensor_deactivation_4_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_time             = sensor; }
         void set_sensor_deactivation_5_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_time             = sensor; }
-        void set_sensor_device_communication(binary_sensor::BinarySensor* sensor)       { m_sensor_device_communication            = sensor; }
+#endif
 
     private:
         void send_request(const char* req);
         void parse_response(const std::string& response);
+#ifdef USE_TEXT_SENSOR
         void parse_slot(const std::string& slot, text_sensor::TextSensor* sensor_code, text_sensor::TextSensor* sensor_time);
+#endif
 
         static float get_temperature(const std::string& input_str)               { return std::atof(input_str.c_str()) / 10;          }
         static float get_number(const std::string& input_str)                    { return std::atoi(input_str.c_str());               }
@@ -119,6 +134,7 @@ namespace esphome::luxtronik_v1
     protected:
         uart::UARTDevice m_device;
 
+#ifdef USE_SENSOR
         // Temperatures
         sensor::Sensor* m_sensor_flow_temperature;                 // 1100:2  - Ist-Temperatur Vorlauf Heizkreis
         sensor::Sensor* m_sensor_return_temperature;               // 1100:3  - Ist-Temperatur Rücklauf Heizkreis
@@ -132,7 +148,9 @@ namespace esphome::luxtronik_v1
         sensor::Sensor* m_sensor_mixed_circuit_1_temperature;      // 1100:11 - Ist-Temperatur Vorlauf Mischkreis 1
         sensor::Sensor* m_sensor_mixed_circuit_1_set_temperature;  // 1100:12 - Soll-Temperatur Vorlauf Mischkreis 1
         sensor::Sensor* m_sensor_remote_adjuster_temperature;      // 1100:13 - Temperatur Raumfernversteller
+#endif
 
+#ifdef USE_BINARY_SENSOR
         // Inputs
         binary_sensor::BinarySensor* m_sensor_defrost_brine_flow;          // 1200:2 - Abtau, Soledruck, Durchfluss
         binary_sensor::BinarySensor* m_sensor_power_provider_lock_period;  // 1200:3 - Sperrzeit EVU
@@ -146,7 +164,6 @@ namespace esphome::luxtronik_v1
         binary_sensor::BinarySensor* m_sensor_hot_water_pump;              // 1300:3   - Brauchwarmwasserumwälzpumpe
         binary_sensor::BinarySensor* m_sensor_floor_heating_pump;          // 1300:4   - Fußbodenheizungsumwälzpumpe
         binary_sensor::BinarySensor* m_sensor_heating_pump;                // 1300:5   - Heizungsumwälzpumpe
-        text_sensor::TextSensor*     m_sensor_mixer_1_state;               // 1700:3,4 - Mischer 1 fährt auf, Mischer 1 fährt zu
         binary_sensor::BinarySensor* m_sensor_housing_ventilation;         // 1300:8   - Ventilation Wärmepumpengehäuse
         binary_sensor::BinarySensor* m_sensor_ventilation_pump;            // 1300:9   - Ventilator, Brunnen- oder Soleumwälzpumpe
         binary_sensor::BinarySensor* m_sensor_compressor_1;                // 1300:10  - Verdichter 1 in Wärmepumpe
@@ -154,6 +171,14 @@ namespace esphome::luxtronik_v1
         binary_sensor::BinarySensor* m_sensor_extra_pump;                  // 1300:12  - Zusatzumwälzpumpe - Zirkulationspumpe
         binary_sensor::BinarySensor* m_sensor_secondary_heater_1;          // 1300:13  - Zweiter Wärmeerzeuger 1
         binary_sensor::BinarySensor* m_sensor_secondary_heater_2_failure;  // 1300:14  - Zweiter Wärmeerzeuger 2 - Sammelstörung
+
+        // Diagnostic
+        binary_sensor::BinarySensor* m_sensor_device_communication;
+#endif
+
+#ifdef USE_TEXT_SENSOR
+        // Outputs
+        text_sensor::TextSensor* m_sensor_mixer_1_state;  // 1300:6,7 - Mischer 1 fährt auf, Mischer 1 fährt zu
 
         // Information
         text_sensor::TextSensor* m_sensor_device_type;        // 1700:2 - Wärmepumpentyp
@@ -188,9 +213,7 @@ namespace esphome::luxtronik_v1
         text_sensor::TextSensor* m_sensor_deactivation_3_time;  // 1600:1602:2-6 - Abschaltung 3 - Datum/Uhrzeit
         text_sensor::TextSensor* m_sensor_deactivation_4_time;  // 1600:1603:2-6 - Abschaltung 4 - Datum/Uhrzeit
         text_sensor::TextSensor* m_sensor_deactivation_5_time;  // 1600:1604:2-6 - Abschaltung 5 - Datum/Uhrzeit
-
-        // Diagnostic
-        binary_sensor::BinarySensor* m_sensor_device_communication;
+#endif
 
         char m_response_buffer[255];
         size_t m_cursor;


### PR DESCRIPTION
This pull request makes all sensors optional at compile time so that the software can be compiled even if all sensors of a specific type are excluded in the YAML file.

Fixes #3