### PR TITLE
Use release tag in GitHub URL of example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Die folgenden generischen Einstellungen können konfiguriert werden:
 
 | Option | Benötigt | Standardwert | Beschreibung |
 | ------ | --------- | ------------- |------------ |
-| `uart_id` | ja | - | Kennung der konfigurierten UART-Komponente (siehe unten) |
+| `uart_id` | ja | - | ID der konfigurierten UART-Komponente (siehe unten) |
 | `update_interval` | nein | 60s | Das Intervall, in dem die Komponente Daten vom Heizungssteuergerät abruft |
 
 ##### Beispiel
@@ -444,7 +444,7 @@ The following generic configuration items can be configured:
 
 | Option | Mandatory | Default Value | Description |
 | ------ | --------- | ------------- |------------ |
-| `uart_id` | yes | n/a | Identifier of the configured UART component (see below) |
+| `uart_id` | yes | n/a | ID of the configured UART component (see below) |
 | `update_interval` | no | 60s | The interval how often the component fetches data from the heating control unit |
 
 ##### Example

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -16,7 +16,7 @@ esp32:
 
 # include Luxtronik V1 component (mandatory)
 external_components:
-  - source: github://jensrossbach/esphome-luxtronik-v1
+  - source: github://jensrossbach/esphome-luxtronik-v1@v1.0.1
     components: [luxtronik_v1]
 
 # enable logging (optional)


### PR DESCRIPTION
This pull request adds a release tag to the GitHub URL in the example configuration in order to bind it to the release and thereby to the code base it belongs to.

Additionally a small textual change in the README file has been done.