### PR TITLE
Improvement measures for mitigating UART communication problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,22 @@ external_components:
 
 Die folgenden generischen Einstellungen können konfiguriert werden:
 
-| Option | Benötigt | Standardwert | Beschreibung |
-| ------ | --------- | ------------- |------------ |
-| `uart_id` | ja | - | ID der konfigurierten UART-Komponente (siehe unten) |
-| `update_interval` | nein | 60s | Das Intervall, in dem die Komponente Daten vom Heizungssteuergerät abruft |
+| Option | Benötigt | Wertebereich | Standardwert | Beschreibung |
+| ------ | -------- | ------------ |------------- | ------------ |
+| `uart_id` | ja | - | - | ID der konfigurierten UART-Komponente (siehe unten) |
+| `update_interval` | nein | Positive Zeitdauer | 60s | Das Intervall, in dem die Komponente Daten vom Heizungssteuergerät abruft |
+| `request_delay` | nein | 0 - 2000 | 0 | Verzögerung in Millisekunden zwischen einzelnen Datensatz-Anfragen |
+| `response_timeout` | nein | 500 - 5000 | 2000 | Maximale Zeit in Millisekunden, die nach einer Datensatz-Anfrage auf die Antwort gewartet wird, bevor ein Wiederholungsversuch gestartet wird |
+| `max_retries` | nein | 0 - 15 | 5 | Maximale Anzahl an Wiederholungsversuchen, bevor mit der nächsten Datensatz-Anfrage fortgefahren wird |
 
 ##### Beispiel
 ```yaml
 luxtronik_v1:
   uart_id: uart_bus
-  update_interval: 300s  # Aktualisierung alle 5 Minuten
+  update_interval: 300s   # Aktualisierung alle 5 Minuten
+  request_delay: 100      # Verzögerung von 100 Millisekunden zwischen den Anfragen
+  response_timeout: 3000  # Maximal 3 Sekunden, bis Antwort kommen muss
+  max_retries: 10         # Maximal 10 Wiederholungsversuche
 ```
 
 ### UART-Komponente
@@ -442,16 +448,22 @@ external_components:
 
 The following generic configuration items can be configured:
 
-| Option | Mandatory | Default Value | Description |
-| ------ | --------- | ------------- |------------ |
-| `uart_id` | yes | n/a | ID of the configured UART component (see below) |
-| `update_interval` | no | 60s | The interval how often the component fetches data from the heating control unit |
+| Option | Mandatory | Value Range | Default Value | Description |
+| ------ | --------- | ----------- |-------------- | ----------- |
+| `uart_id` | yes | n/a | n/a | ID of the configured UART component (see below) |
+| `update_interval` | no | Positive duration | 60s | The interval how often the component fetches data from the heating control unit |
+| `request_delay` | no | 0 - 2000 | 0 | Delay in milliseconds between individual dataset requests |
+| `response_timeout` | no | 500 - 5000 | 2000 | Maximum time in milliseconds to wait for a response after a dataset request before a retry is done |
+| `max_retries` | no | 0 - 15 | 5 | Maximum number of retries before proceeding with next dataset request |
 
 ##### Example
 ```yaml
 luxtronik_v1:
   uart_id: uart_bus
-  update_interval: 300s  # update every 5 minutes
+  update_interval: 300s   # update every 5 minutes
+  request_delay: 100      # delay of 100 milliseconds between requests
+  response_timeout: 3000  # a maximum of 3 seconds until response is expected
+  max_retries: 10         # retry a maximum of 10 times
 ```
 
 ### UART Component

--- a/components/luxtronik_v1/__init__.py
+++ b/components/luxtronik_v1/__init__.py
@@ -34,18 +34,30 @@ from esphome.const      import (
 CODEOWNERS = ["@jensrossbach"]
 DEPENDENCIES = ["uart"]
 
-CONF_LUXTRONIK_ID = "luxtronik_id"
+CONF_LUXTRONIK_ID     = "luxtronik_id"
+CONF_REQUEST_DELAY    = "request_delay"
+CONF_RESPONSE_TIMEOUT = "response_timeout"
+CONF_MAX_RETRIES      = "max_retries"
+
 
 luxtronik_ns = cg.esphome_ns.namespace("luxtronik_v1")
 Luxtronik = luxtronik_ns.class_("Luxtronik", cg.PollingComponent)
 
 CONFIG_SCHEMA = cv.Schema(
 {
-    cv.GenerateID(): cv.declare_id(Luxtronik)
+    cv.GenerateID(): cv.declare_id(Luxtronik),
+    cv.Optional(CONF_REQUEST_DELAY, default = 0): cv.int_range(min = 0, max = 2000),
+    cv.Optional(CONF_RESPONSE_TIMEOUT, default = 2000): cv.int_range(min = 500, max = 5000),
+    cv.Optional(CONF_MAX_RETRIES, default = 5): cv.int_range(min = 0, max = 15)
 }).extend(uart.UART_DEVICE_SCHEMA).extend(cv.polling_component_schema("60s"))
 
 
 async def to_code(config):
     uart_cmp = await cg.get_variable(config[CONF_UART_ID])
-    cmp = cg.new_Pvariable(config[CONF_ID], uart_cmp)
+    cmp = cg.new_Pvariable(
+                config[CONF_ID],
+                uart_cmp,
+                config[CONF_REQUEST_DELAY],
+                config[CONF_RESPONSE_TIMEOUT],
+                config[CONF_MAX_RETRIES])
     await cg.register_component(cmp, config)

--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -351,9 +351,22 @@ namespace esphome::luxtronik_v1
 #endif
     }
 
+    void Luxtronik::clear_uart_buffer()
+    {
+        uint8_t byte;
+
+        while (m_device.available())
+        {
+            m_device.read_byte(&byte);
+        }
+    }
+
     void Luxtronik::send_request(const char* request)
     {
         ESP_LOGD(TAG, "Sending request:  DATA %s", request);
+
+        // ensure we have an empty UART buffer for next request
+        clear_uart_buffer();
 
         m_device.write_str(request);
         m_device.write_byte(ASCII_CR);

--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -98,7 +98,7 @@ namespace esphome::luxtronik_v1
                                                     RESPONSE_HEATING_MODE|
                                                     RESPONSE_HOT_WATER_MODE;
 
-    enum class DeviceType
+    enum class DeviceType : uint8_t
     {
         ERC =  0,
         SW1 =  1,
@@ -117,14 +117,14 @@ namespace esphome::luxtronik_v1
         WZS = 14
     };
 
-    enum class BivalenceLevel
+    enum class BivalenceLevel : uint8_t
     {
         SINGLE_COMPRESSOR = 1,
         DUAL_COMPRESSOR   = 2,
         ADDITIONAL_HEATER = 3
     };
 
-    enum class OperationalState
+    enum class OperationalState : uint8_t
     {
         HEAT          = 0,
         HOT_WATER     = 1,
@@ -134,7 +134,7 @@ namespace esphome::luxtronik_v1
         STANDBY       = 5
     };
 
-    enum class OperationalMode
+    enum class OperationalMode : uint8_t
     {
         AUTO          = 0,
         SECOND_HEATER = 1,
@@ -150,69 +150,63 @@ namespace esphome::luxtronik_v1
                     uint16_t max_retries)
         : PollingComponent()
         , m_device(uart)
-#ifdef USE_SENSOR
-        , m_sensor_flow_temperature(nullptr)
-        , m_sensor_return_temperature(nullptr)
-        , m_sensor_return_set_temperature(nullptr)
-        , m_sensor_hot_gas_temperature(nullptr)
-        , m_sensor_outside_temperature(nullptr)
-        , m_sensor_hot_water_temperature(nullptr)
-        , m_sensor_hot_water_set_temperature(nullptr)
-        , m_sensor_heat_source_input_temperature(nullptr)
-        , m_sensor_heat_source_output_temperature(nullptr)
-        , m_sensor_mixed_circuit_1_temperature(nullptr)
-        , m_sensor_mixed_circuit_1_set_temperature(nullptr)
-        , m_sensor_remote_adjuster_temperature(nullptr)
-#endif
-#ifdef USE_BINARY_SENSOR
-        , m_sensor_defrost_brine_flow(nullptr)
-        , m_sensor_power_provider_lock_period(nullptr)
-        , m_sensor_high_pressure_state(nullptr)
-        , m_sensor_engine_protection(nullptr)
-        , m_sensor_low_pressure_state(nullptr)
-        , m_sensor_external_power(nullptr)
-        , m_sensor_defrost_valve(nullptr)
-        , m_sensor_hot_water_pump(nullptr)
-        , m_sensor_floor_heating_pump(nullptr)
-        , m_sensor_heating_pump(nullptr)
-        , m_sensor_housing_ventilation(nullptr)
-        , m_sensor_ventilation_pump(nullptr)
-        , m_sensor_compressor_1(nullptr)
-        , m_sensor_compressor_2(nullptr)
-        , m_sensor_extra_pump(nullptr)
-        , m_sensor_secondary_heater_1(nullptr)
-        , m_sensor_secondary_heater_2_failure(nullptr)
-        , m_sensor_device_communication(nullptr)
-#endif
-#ifdef USE_TEXT_SENSOR
-        , m_sensor_mixer_1_state(nullptr)
-        , m_sensor_device_type(nullptr)
-        , m_sensor_firmware_version(nullptr)
-        , m_sensor_bivalence_level(nullptr)
-        , m_sensor_operational_state(nullptr)
-        , m_sensor_heating_mode(nullptr)
-        , m_sensor_hot_water_mode(nullptr)
-        , m_sensor_error_1_code(nullptr)
-        , m_sensor_error_2_code(nullptr)
-        , m_sensor_error_3_code(nullptr)
-        , m_sensor_error_4_code(nullptr)
-        , m_sensor_error_5_code(nullptr)
-        , m_sensor_error_1_time(nullptr)
-        , m_sensor_error_2_time(nullptr)
-        , m_sensor_error_3_time(nullptr)
-        , m_sensor_error_4_time(nullptr)
-        , m_sensor_error_5_time(nullptr)
-        , m_sensor_deactivation_1_code(nullptr)
-        , m_sensor_deactivation_2_code(nullptr)
-        , m_sensor_deactivation_3_code(nullptr)
-        , m_sensor_deactivation_4_code(nullptr)
-        , m_sensor_deactivation_5_code(nullptr)
-        , m_sensor_deactivation_1_time(nullptr)
-        , m_sensor_deactivation_2_time(nullptr)
-        , m_sensor_deactivation_3_time(nullptr)
-        , m_sensor_deactivation_4_time(nullptr)
-        , m_sensor_deactivation_5_time(nullptr)
-#endif
+        , m_sensor_flow_temperature()
+        , m_sensor_return_temperature()
+        , m_sensor_return_set_temperature()
+        , m_sensor_hot_gas_temperature()
+        , m_sensor_outside_temperature()
+        , m_sensor_hot_water_temperature()
+        , m_sensor_hot_water_set_temperature()
+        , m_sensor_heat_source_input_temperature()
+        , m_sensor_heat_source_output_temperature()
+        , m_sensor_mixed_circuit_1_temperature()
+        , m_sensor_mixed_circuit_1_set_temperature()
+        , m_sensor_remote_adjuster_temperature()
+        , m_sensor_defrost_brine_flow()
+        , m_sensor_power_provider_lock_period()
+        , m_sensor_high_pressure_state()
+        , m_sensor_engine_protection()
+        , m_sensor_low_pressure_state()
+        , m_sensor_external_power()
+        , m_sensor_defrost_valve()
+        , m_sensor_hot_water_pump()
+        , m_sensor_floor_heating_pump()
+        , m_sensor_heating_pump()
+        , m_sensor_mixer_1_state()
+        , m_sensor_housing_ventilation()
+        , m_sensor_ventilation_pump()
+        , m_sensor_compressor_1()
+        , m_sensor_compressor_2()
+        , m_sensor_extra_pump()
+        , m_sensor_secondary_heater_1()
+        , m_sensor_secondary_heater_2_failure()
+        , m_sensor_device_type()
+        , m_sensor_firmware_version()
+        , m_sensor_bivalence_level()
+        , m_sensor_operational_state()
+        , m_sensor_heating_mode()
+        , m_sensor_hot_water_mode()
+        , m_sensor_error_1_code()
+        , m_sensor_error_2_code()
+        , m_sensor_error_3_code()
+        , m_sensor_error_4_code()
+        , m_sensor_error_5_code()
+        , m_sensor_error_1_time()
+        , m_sensor_error_2_time()
+        , m_sensor_error_3_time()
+        , m_sensor_error_4_time()
+        , m_sensor_error_5_time()
+        , m_sensor_deactivation_1_code()
+        , m_sensor_deactivation_2_code()
+        , m_sensor_deactivation_3_code()
+        , m_sensor_deactivation_4_code()
+        , m_sensor_deactivation_5_code()
+        , m_sensor_deactivation_1_time()
+        , m_sensor_deactivation_2_time()
+        , m_sensor_deactivation_3_time()
+        , m_sensor_deactivation_4_time()
+        , m_sensor_deactivation_5_time()
+        , m_sensor_device_communication()
         , m_request_delay(request_delay)
         , m_response_timeout(response_timeout)
         , m_max_retries(max_retries)
@@ -225,6 +219,25 @@ namespace esphome::luxtronik_v1
         , m_current_request(0)
         , m_timer()
     {
+    }
+
+    void Luxtronik::update()
+    {
+        m_timer.cancel();
+
+        if (m_received_responses != RESPONSE_ALL)
+        {
+            ESP_LOGW(TAG, "No full response from Luxtronik in last update cycle:  RESP %04X", m_received_responses);
+        }
+
+        m_sensor_device_communication.set_state(m_received_responses != RESPONSE_ALL);
+
+        m_received_responses = RESPONSE_NONE;
+        m_retry_count = 0;
+
+        // request temperatures
+        m_current_request = 0;
+        request_data();
     }
 
     void Luxtronik::loop()
@@ -286,30 +299,6 @@ namespace esphome::luxtronik_v1
         }
     }
 
-    void Luxtronik::update()
-    {
-        m_timer.cancel();
-
-        if (m_received_responses != RESPONSE_ALL)
-        {
-            ESP_LOGW(TAG, "No full response from Luxtronik in last update cycle:  RESP %04X", m_received_responses);
-        }
-
-#ifdef USE_BINARY_SENSOR
-        if (m_sensor_device_communication != nullptr)
-        {
-            m_sensor_device_communication->publish_state(m_received_responses != RESPONSE_ALL);
-        }
-#endif
-
-        m_received_responses = RESPONSE_NONE;
-        m_retry_count = 0;
-
-        // request temperatures
-        m_current_request = 0;
-        request_data();
-    }
-
     void Luxtronik::dump_config()
     {
         ESP_LOGCONFIG(TAG, "Luxtronik V1");
@@ -319,67 +308,67 @@ namespace esphome::luxtronik_v1
         ESP_LOGCONFIG(TAG, "  Max. number of retries: %u", m_max_retries);
 
 #ifdef USE_SENSOR
-        LOG_SENSOR("", "Flow Temperture Sensor", m_sensor_flow_temperature);
-        LOG_SENSOR("", "Return Temperture Sensor", m_sensor_return_temperature);
-        LOG_SENSOR("", "Return Set-Temperture Sensor", m_sensor_return_set_temperature);
-        LOG_SENSOR("", "Hot Gas Temperture Sensor", m_sensor_hot_gas_temperature);
-        LOG_SENSOR("", "Hot Water Temperture Sensor", m_sensor_hot_water_temperature);
-        LOG_SENSOR("", "Hot Water Set-Temperture Sensor", m_sensor_hot_water_set_temperature);
-        LOG_SENSOR("", "Outside Temperture Sensor", m_sensor_outside_temperature);
-        LOG_SENSOR("", "Heat-Source Input Temperture Sensor", m_sensor_heat_source_input_temperature);
-        LOG_SENSOR("", "Heat-Source Output Temperture Sensor", m_sensor_heat_source_output_temperature);
-        LOG_SENSOR("", "Mixed Circuit 1 Temperture Sensor", m_sensor_mixed_circuit_1_temperature);
-        LOG_SENSOR("", "Mixed Circuit 1 Set-Temperture Sensor", m_sensor_mixed_circuit_1_set_temperature);
-        LOG_SENSOR("", "Remote Adjuster Temperture Sensor", m_sensor_remote_adjuster_temperature);
+        LOG_SENSOR("", "Flow Temperture Sensor", m_sensor_flow_temperature.get_sensor());
+        LOG_SENSOR("", "Return Temperture Sensor", m_sensor_return_temperature.get_sensor());
+        LOG_SENSOR("", "Return Set-Temperture Sensor", m_sensor_return_set_temperature.get_sensor());
+        LOG_SENSOR("", "Hot Gas Temperture Sensor", m_sensor_hot_gas_temperature.get_sensor());
+        LOG_SENSOR("", "Hot Water Temperture Sensor", m_sensor_hot_water_temperature.get_sensor());
+        LOG_SENSOR("", "Hot Water Set-Temperture Sensor", m_sensor_hot_water_set_temperature.get_sensor());
+        LOG_SENSOR("", "Outside Temperture Sensor", m_sensor_outside_temperature.get_sensor());
+        LOG_SENSOR("", "Heat-Source Input Temperture Sensor", m_sensor_heat_source_input_temperature.get_sensor());
+        LOG_SENSOR("", "Heat-Source Output Temperture Sensor", m_sensor_heat_source_output_temperature.get_sensor());
+        LOG_SENSOR("", "Mixed Circuit 1 Temperture Sensor", m_sensor_mixed_circuit_1_temperature.get_sensor());
+        LOG_SENSOR("", "Mixed Circuit 1 Set-Temperture Sensor", m_sensor_mixed_circuit_1_set_temperature.get_sensor());
+        LOG_SENSOR("", "Remote Adjuster Temperture Sensor", m_sensor_remote_adjuster_temperature.get_sensor());
 #endif
 
 #ifdef USE_BINARY_SENSOR
-        LOG_BINARY_SENSOR("", "Defrost/Brine/Flow Sensor", m_sensor_defrost_brine_flow);
-        LOG_BINARY_SENSOR("", "Power Provider Lock Period Sensor", m_sensor_power_provider_lock_period);
-        LOG_BINARY_SENSOR("", "Low Pressure State Sensor", m_sensor_low_pressure_state);
-        LOG_BINARY_SENSOR("", "High Pressure State Sensor", m_sensor_high_pressure_state);
-        LOG_BINARY_SENSOR("", "Engine Protection Sensor", m_sensor_engine_protection);
-        LOG_BINARY_SENSOR("", "External Power Sensor", m_sensor_external_power);
-        LOG_BINARY_SENSOR("", "Defrost Valve Sensor", m_sensor_defrost_valve);
-        LOG_BINARY_SENSOR("", "Hot Water Pump Sensor", m_sensor_hot_water_pump);
-        LOG_BINARY_SENSOR("", "Heating Pump Sensor", m_sensor_heating_pump);
-        LOG_BINARY_SENSOR("", "Floor Heating Pump Sensor", m_sensor_floor_heating_pump);
-        LOG_BINARY_SENSOR("", "Ventilation/Pump Sensor", m_sensor_ventilation_pump);
-        LOG_BINARY_SENSOR("", "Housing Ventilation Sensor", m_sensor_housing_ventilation);
-        LOG_BINARY_SENSOR("", "Compressor 1 Sensor", m_sensor_compressor_1);
-        LOG_BINARY_SENSOR("", "Compressor 2 Sensor", m_sensor_compressor_2);
-        LOG_BINARY_SENSOR("", "Extra Pump Sensor", m_sensor_extra_pump);
-        LOG_BINARY_SENSOR("", "Secondary Heater 1 Sensor", m_sensor_secondary_heater_1);
-        LOG_BINARY_SENSOR("", "Secondary Heater 2 Failure Sensor", m_sensor_secondary_heater_2_failure);
-        LOG_BINARY_SENSOR("", "Device Communication Sensor", m_sensor_device_communication);
+        LOG_BINARY_SENSOR("", "Defrost/Brine/Flow Sensor", m_sensor_defrost_brine_flow.get_sensor());
+        LOG_BINARY_SENSOR("", "Power Provider Lock Period Sensor", m_sensor_power_provider_lock_period.get_sensor());
+        LOG_BINARY_SENSOR("", "Low Pressure State Sensor", m_sensor_low_pressure_state.get_sensor());
+        LOG_BINARY_SENSOR("", "High Pressure State Sensor", m_sensor_high_pressure_state.get_sensor());
+        LOG_BINARY_SENSOR("", "Engine Protection Sensor", m_sensor_engine_protection.get_sensor());
+        LOG_BINARY_SENSOR("", "External Power Sensor", m_sensor_external_power.get_sensor());
+        LOG_BINARY_SENSOR("", "Defrost Valve Sensor", m_sensor_defrost_valve.get_sensor());
+        LOG_BINARY_SENSOR("", "Hot Water Pump Sensor", m_sensor_hot_water_pump.get_sensor());
+        LOG_BINARY_SENSOR("", "Heating Pump Sensor", m_sensor_heating_pump.get_sensor());
+        LOG_BINARY_SENSOR("", "Floor Heating Pump Sensor", m_sensor_floor_heating_pump.get_sensor());
+        LOG_BINARY_SENSOR("", "Ventilation/Pump Sensor", m_sensor_ventilation_pump.get_sensor());
+        LOG_BINARY_SENSOR("", "Housing Ventilation Sensor", m_sensor_housing_ventilation.get_sensor());
+        LOG_BINARY_SENSOR("", "Compressor 1 Sensor", m_sensor_compressor_1.get_sensor());
+        LOG_BINARY_SENSOR("", "Compressor 2 Sensor", m_sensor_compressor_2.get_sensor());
+        LOG_BINARY_SENSOR("", "Extra Pump Sensor", m_sensor_extra_pump.get_sensor());
+        LOG_BINARY_SENSOR("", "Secondary Heater 1 Sensor", m_sensor_secondary_heater_1.get_sensor());
+        LOG_BINARY_SENSOR("", "Secondary Heater 2 Failure Sensor", m_sensor_secondary_heater_2_failure.get_sensor());
+        LOG_BINARY_SENSOR("", "Device Communication Sensor", m_sensor_device_communication.get_sensor());
 #endif
 
 #ifdef USE_TEXT_SENSOR
-        LOG_TEXT_SENSOR("", "Mixer 1 Sensor", m_sensor_mixer_1_state);
-        LOG_TEXT_SENSOR("", "Device Type Sensor", m_sensor_device_type);
-        LOG_TEXT_SENSOR("", "Firmware Version Sensor", m_sensor_firmware_version);
-        LOG_TEXT_SENSOR("", "Bivalence Level Sensor", m_sensor_bivalence_level);
-        LOG_TEXT_SENSOR("", "Operational State Sensor", m_sensor_operational_state);
-        LOG_TEXT_SENSOR("", "Error 1 Code Sensor", m_sensor_error_1_code);
-        LOG_TEXT_SENSOR("", "Error 2 Code Sensor", m_sensor_error_2_code);
-        LOG_TEXT_SENSOR("", "Error 3 Code Sensor", m_sensor_error_3_code);
-        LOG_TEXT_SENSOR("", "Error 4 Code Sensor", m_sensor_error_4_code);
-        LOG_TEXT_SENSOR("", "Error 5 Code Sensor", m_sensor_error_5_code);
-        LOG_TEXT_SENSOR("", "Error 1 Time Sensor", m_sensor_error_1_time);
-        LOG_TEXT_SENSOR("", "Error 2 Time Sensor", m_sensor_error_2_time);
-        LOG_TEXT_SENSOR("", "Error 3 Time Sensor", m_sensor_error_3_time);
-        LOG_TEXT_SENSOR("", "Error 4 Time Sensor", m_sensor_error_4_time);
-        LOG_TEXT_SENSOR("", "Error 5 Time Sensor", m_sensor_error_5_time);
-        LOG_TEXT_SENSOR("", "Deactivation 1 Code Sensor", m_sensor_deactivation_1_code);
-        LOG_TEXT_SENSOR("", "Deactivation 2 Code Sensor", m_sensor_deactivation_2_code);
-        LOG_TEXT_SENSOR("", "Deactivation 3 Code Sensor", m_sensor_deactivation_3_code);
-        LOG_TEXT_SENSOR("", "Deactivation 4 Code Sensor", m_sensor_deactivation_4_code);
-        LOG_TEXT_SENSOR("", "Deactivation 5 Code Sensor", m_sensor_deactivation_5_time);
-        LOG_TEXT_SENSOR("", "Deactivation 1 Time Sensor", m_sensor_deactivation_1_time);
-        LOG_TEXT_SENSOR("", "Deactivation 2 Time Sensor", m_sensor_deactivation_2_time);
-        LOG_TEXT_SENSOR("", "Deactivation 3 Time Sensor", m_sensor_deactivation_3_time);
-        LOG_TEXT_SENSOR("", "Deactivation 4 Time Sensor", m_sensor_deactivation_4_time);
-        LOG_TEXT_SENSOR("", "Deactivation 5 Time Sensor", m_sensor_deactivation_5_code);
+        LOG_TEXT_SENSOR("", "Mixer 1 Sensor", m_sensor_mixer_1_state.get_sensor());
+        LOG_TEXT_SENSOR("", "Device Type Sensor", m_sensor_device_type.get_sensor());
+        LOG_TEXT_SENSOR("", "Firmware Version Sensor", m_sensor_firmware_version.get_sensor());
+        LOG_TEXT_SENSOR("", "Bivalence Level Sensor", m_sensor_bivalence_level.get_sensor());
+        LOG_TEXT_SENSOR("", "Operational State Sensor", m_sensor_operational_state.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 1 Code Sensor", m_sensor_error_1_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 2 Code Sensor", m_sensor_error_2_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 3 Code Sensor", m_sensor_error_3_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 4 Code Sensor", m_sensor_error_4_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 5 Code Sensor", m_sensor_error_5_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 1 Time Sensor", m_sensor_error_1_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 2 Time Sensor", m_sensor_error_2_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 3 Time Sensor", m_sensor_error_3_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 4 Time Sensor", m_sensor_error_4_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Error 5 Time Sensor", m_sensor_error_5_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 1 Code Sensor", m_sensor_deactivation_1_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 2 Code Sensor", m_sensor_deactivation_2_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 3 Code Sensor", m_sensor_deactivation_3_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 4 Code Sensor", m_sensor_deactivation_4_code.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 5 Code Sensor", m_sensor_deactivation_5_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 1 Time Sensor", m_sensor_deactivation_1_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 2 Time Sensor", m_sensor_deactivation_2_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 3 Time Sensor", m_sensor_deactivation_3_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 4 Time Sensor", m_sensor_deactivation_4_time.get_sensor());
+        LOG_TEXT_SENSOR("", "Deactivation 5 Time Sensor", m_sensor_deactivation_5_code.get_sensor());
 #endif
     }
 
@@ -465,147 +454,51 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_flow_temperature != nullptr)
-            {
-                m_sensor_flow_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_flow_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_return_temperature != nullptr)
-            {
-                m_sensor_return_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_return_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_return_set_temperature != nullptr)
-            {
-                m_sensor_return_set_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_return_set_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_hot_gas_temperature != nullptr)
-            {
-                m_sensor_hot_gas_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_hot_gas_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_outside_temperature != nullptr)
-            {
-                m_sensor_outside_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_outside_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_hot_water_temperature != nullptr)
-            {
-                m_sensor_hot_water_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_hot_water_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_hot_water_set_temperature != nullptr)
-            {
-                m_sensor_hot_water_set_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_hot_water_set_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_heat_source_input_temperature != nullptr)
-            {
-                m_sensor_heat_source_input_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_heat_source_input_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_heat_source_output_temperature != nullptr)
-            {
-                m_sensor_heat_source_output_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_heat_source_output_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_mixed_circuit_1_temperature != nullptr)
-            {
-                m_sensor_mixed_circuit_1_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_mixed_circuit_1_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_mixed_circuit_1_set_temperature != nullptr)
-            {
-                m_sensor_mixed_circuit_1_set_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_mixed_circuit_1_set_temperature.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_SENSOR
-            if (m_sensor_remote_adjuster_temperature != nullptr)
-            {
-                m_sensor_remote_adjuster_temperature->
-                    publish_state(
-                        get_temperature(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_remote_adjuster_temperature.set_state(response, start, end);
 
             m_received_responses |= RESPONSE_TEMPERATURES;
 
@@ -622,75 +515,27 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_defrost_brine_flow != nullptr)
-            {
-                m_sensor_defrost_brine_flow->
-                    publish_state(
-                        get_binary_state(  // on = defrost ending or flow rate ok (depending on device type)
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_defrost_brine_flow.set_state(response, start, end);  // on = defrost ending or flow rate ok (depending on device type)
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_power_provider_lock_period != nullptr)
-            {
-                m_sensor_power_provider_lock_period->
-                    publish_state(
-                        get_binary_state(  // off = lock period, on = not locked
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_power_provider_lock_period.set_state(response, start, end);  // off = lock period, on = not locked
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_high_pressure_state != nullptr)
-            {
-                m_sensor_high_pressure_state->
-                    publish_state(
-                        get_binary_state(  // off = pressure ok, on = not ok
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_high_pressure_state.set_state(response, start, end);  // off = pressure ok, on = not ok
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_engine_protection != nullptr)
-            {
-                m_sensor_engine_protection->
-                    publish_state(
-                        !get_binary_state(  // on = engine protection ok, off = not ok
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_engine_protection.set_state(response, start, end, true);  // on = engine protection ok, off = not ok
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_low_pressure_state != nullptr)
-            {
-                m_sensor_low_pressure_state->
-                    publish_state(
-                        !get_binary_state(  // on = pressure ok, off = not ok
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_low_pressure_state.set_state(response, start, end, true);  // on = pressure ok, off = not ok
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_external_power != nullptr)
-            {
-                m_sensor_external_power->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_external_power.set_state(response, start, end);
 
             m_received_responses |= RESPONSE_INPUTS;
 
@@ -707,157 +552,63 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_defrost_valve != nullptr)
-            {
-                m_sensor_defrost_valve->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_defrost_valve.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_hot_water_pump != nullptr)
-            {
-                m_sensor_hot_water_pump->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_hot_water_pump.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_floor_heating_pump != nullptr)
-            {
-                m_sensor_floor_heating_pump->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_floor_heating_pump.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_heating_pump != nullptr)
-            {
-                m_sensor_heating_pump->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_heating_pump.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            bool mixerOpen = get_binary_state(response.substr(start, end - start));
+            bool mixerOpen = get_binary_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            bool mixerClose = get_binary_state(response.substr(start, end - start));
+            bool mixerClose = get_binary_state(response, start, end);
 
-#ifdef USE_TEXT_SENSOR
             // merge the two separate states (Mischer 1 fährt auf, Mischer 1 fährt zu) into one sensor
-            if (m_sensor_mixer_1_state != nullptr)
-            {
-                m_sensor_mixer_1_state->
-                    publish_state(
-                        mixerOpen
-                            ? "opening"
-                            : mixerClose
-                                ? "closing"
-                                : "idle");
-            }
-#endif
+            m_sensor_mixer_1_state.set_state(
+                    mixerOpen
+                        ? "opening"
+                        : mixerClose
+                            ? "closing"
+                            : "idle");
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_housing_ventilation != nullptr)
-            {
-                m_sensor_housing_ventilation->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_housing_ventilation.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_ventilation_pump != nullptr)
-            {
-                m_sensor_ventilation_pump->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_ventilation_pump.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_compressor_1 != nullptr)
-            {
-                m_sensor_compressor_1->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_compressor_1.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_compressor_2 != nullptr)
-            {
-                m_sensor_compressor_2->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_compressor_2.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_extra_pump != nullptr)
-            {
-                m_sensor_extra_pump->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_extra_pump.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_secondary_heater_1 != nullptr)
-            {
-                m_sensor_secondary_heater_1->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_secondary_heater_1.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_BINARY_SENSOR
-            if (m_sensor_secondary_heater_2_failure != nullptr)
-            {
-                m_sensor_secondary_heater_2_failure->
-                    publish_state(
-                        get_binary_state(
-                            response.substr(start, end - start)));
-            }
-#endif
+            m_sensor_secondary_heater_2_failure.set_state(response, start, end);
 
             m_received_responses |= RESPONSE_OUTPUTS;
 
@@ -870,7 +621,6 @@ namespace esphome::luxtronik_v1
 
             if ((response.length() >= MIN_SLOT_LENGTH) && starts_with(response, TYPE_ERRORS_SLOT))
             {
-#ifdef USE_TEXT_SENSOR
                 char slotID = response.at(INDEX_SLOT_ID);
                 switch (slotID)
                 {
@@ -880,7 +630,6 @@ namespace esphome::luxtronik_v1
                     case SLOT_4_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_4_code, m_sensor_error_4_time); break; }
                     case SLOT_5_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_5_code, m_sensor_error_5_time); break; }
                 }
-#endif
             }
             else if (!m_slot_block)
             {
@@ -901,7 +650,6 @@ namespace esphome::luxtronik_v1
 
             if ((response.length() >= MIN_SLOT_LENGTH) && starts_with(response, TYPE_DEACTIVATIONS_SLOT))
             {
-#ifdef USE_TEXT_SENSOR
                 char slotID = response.at(INDEX_SLOT_ID);
                 switch (slotID)
                 {
@@ -911,7 +659,6 @@ namespace esphome::luxtronik_v1
                     case SLOT_4_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_4_code, m_sensor_deactivation_4_time); break; }
                     case SLOT_5_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_5_code, m_sensor_deactivation_5_time); break; }
                 }
-#endif
             }
             else if (!m_slot_block)
             {
@@ -930,90 +677,85 @@ namespace esphome::luxtronik_v1
         {
             m_timer.cancel();
 
-            int32_t value = 0;
-            std::string text = "";
             size_t start = INDEX_RESPONSE_START;
             size_t end = response.find(DELIMITER, start);
             // skip number of elements
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_TEXT_SENSOR
-            if (m_sensor_device_type != nullptr)
+
+            if (m_sensor_device_type.has_sensor())
             {
-                value = std::atoi(response.substr(start, end - start).c_str());
+                std::string state = "";
+                int32_t value = get_number(response, start, end);
+
                 switch (static_cast<DeviceType>(value))
                 {
-                    case DeviceType::ERC: { text = "ERC";                 break; }
-                    case DeviceType::SW1: { text = "SW1";                 break; }
-                    case DeviceType::SW2: { text = "SW2";                 break; }
-                    case DeviceType::WW1: { text = "WW1";                 break; }
-                    case DeviceType::WW2: { text = "WW2";                 break; }
-                    case DeviceType::L1I: { text = "L1I";                 break; }
-                    case DeviceType::L2I: { text = "L2I";                 break; }
-                    case DeviceType::L1A: { text = "L1A";                 break; }
-                    case DeviceType::L2A: { text = "L2A";                 break; }
-                    case DeviceType::KSW: { text = "KSW";                 break; }
-                    case DeviceType::KLW: { text = "KLW";                 break; }
-                    case DeviceType::SWC: { text = "SWC";                 break; }
-                    case DeviceType::LWC: { text = "LWC";                 break; }
-                    case DeviceType::L2G: { text = "L2G";                 break; }
-                    case DeviceType::WZS: { text = "WZS";                 break; }
-                    default:              { text = std::to_string(value); break; }
+                    case DeviceType::ERC: { state = "ERC";                 break; }
+                    case DeviceType::SW1: { state = "SW1";                 break; }
+                    case DeviceType::SW2: { state = "SW2";                 break; }
+                    case DeviceType::WW1: { state = "WW1";                 break; }
+                    case DeviceType::WW2: { state = "WW2";                 break; }
+                    case DeviceType::L1I: { state = "L1I";                 break; }
+                    case DeviceType::L2I: { state = "L2I";                 break; }
+                    case DeviceType::L1A: { state = "L1A";                 break; }
+                    case DeviceType::L2A: { state = "L2A";                 break; }
+                    case DeviceType::KSW: { state = "KSW";                 break; }
+                    case DeviceType::KLW: { state = "KLW";                 break; }
+                    case DeviceType::SWC: { state = "SWC";                 break; }
+                    case DeviceType::LWC: { state = "LWC";                 break; }
+                    case DeviceType::L2G: { state = "L2G";                 break; }
+                    case DeviceType::WZS: { state = "WZS";                 break; }
+                    default:              { state = std::to_string(value); break; }
                 }
-                m_sensor_device_type->publish_state(text);
+
+                m_sensor_device_type.set_state(state);
             }
-#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_TEXT_SENSOR
-            if (m_sensor_firmware_version != nullptr)
-            {
-                m_sensor_firmware_version->
-                    publish_state(
-                        response.substr(
-                            start + 1,  // version without 'V' prefix
-                            end - start - 1));
-            }
-#endif
+            m_sensor_firmware_version.set_state(response, start + 1, end);  // skip leading space
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_TEXT_SENSOR
-            if (m_sensor_bivalence_level != nullptr)
+
+            if (m_sensor_bivalence_level.has_sensor())
             {
-                value = std::atoi(response.substr(start, end - start).c_str());
+                std::string state = "";
+                int32_t value = get_number(response, start, end);
+
                 switch (static_cast<BivalenceLevel>(value))
                 {
-                    case BivalenceLevel::SINGLE_COMPRESSOR: { text = "single_compressor";   break; }
-                    case BivalenceLevel::DUAL_COMPRESSOR:   { text = "dual_compressor";     break; }
-                    case BivalenceLevel::ADDITIONAL_HEATER: { text = "additional_heater";   break; }
-                    default:                                { text = std::to_string(value); break; }
+                    case BivalenceLevel::SINGLE_COMPRESSOR: { state = "single_compressor";   break; }
+                    case BivalenceLevel::DUAL_COMPRESSOR:   { state = "dual_compressor";     break; }
+                    case BivalenceLevel::ADDITIONAL_HEATER: { state = "additional_heater";   break; }
+                    default:                                { state = std::to_string(value); break; }
                 }
-                m_sensor_bivalence_level->publish_state(text);
+
+                m_sensor_bivalence_level.set_state(state);
             }
-#endif
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_TEXT_SENSOR
-            if (m_sensor_operational_state != nullptr)
+
+            if (m_sensor_operational_state.has_sensor())
             {
-                value = std::atoi(response.substr(start, end - start).c_str());
+                std::string state = "";
+                int32_t value = get_number(response, start, end);
+
                 switch (static_cast<OperationalState>(value))
                 {
-                    case OperationalState::HEAT:          { text = "heat";                break; }
-                    case OperationalState::HOT_WATER:     { text = "hot_water";           break; }
-                    case OperationalState::SWIMMING_POOL: { text = "swimming_pool";       break; }
-                    case OperationalState::PROVIDER_LOCK: { text = "provider_lock";       break; }
-                    case OperationalState::DEFROST:       { text = "defrost";             break; }
-                    case OperationalState::STANDBY:       { text = "standby";             break; }
-                    default:                              { text = std::to_string(value); break; }
+                    case OperationalState::HEAT:          { state = "heat";                break; }
+                    case OperationalState::HOT_WATER:     { state = "hot_water";           break; }
+                    case OperationalState::SWIMMING_POOL: { state = "swimming_pool";       break; }
+                    case OperationalState::PROVIDER_LOCK: { state = "provider_lock";       break; }
+                    case OperationalState::DEFROST:       { state = "defrost";             break; }
+                    case OperationalState::STANDBY:       { state = "standby";             break; }
+                    default:                              { state = std::to_string(value); break; }
                 }
-                m_sensor_operational_state->publish_state(text);
+
+                m_sensor_operational_state.set_state(state);
             }
-#endif
 
             m_received_responses |= RESPONSE_INFORMATION;
 
@@ -1024,30 +766,30 @@ namespace esphome::luxtronik_v1
         {
             m_timer.cancel();
 
-            int32_t value = 0;
-            std::string text = "";
             size_t start = INDEX_RESPONSE_START;
             size_t end = response.find(DELIMITER, start);
             // skip number of elements
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_TEXT_SENSOR
-            if (m_sensor_heating_mode != nullptr)
+
+            if (m_sensor_heating_mode.has_sensor())
             {
-                value = std::atoi(response.substr(start, end - start).c_str());
+                std::string state = "";
+                int32_t value = get_number(response, start, end);
+
                 switch (static_cast<OperationalMode>(value))
                 {
-                    case OperationalMode::AUTO:          { text = "auto";                break; }
-                    case OperationalMode::SECOND_HEATER: { text = "second_heater";       break; }
-                    case OperationalMode::PARTY:         { text = "party";               break; }
-                    case OperationalMode::VACATION:      { text = "vacation";            break; }
-                    case OperationalMode::OFF:           { text = "off";                 break; }
-                    default:                             { text = std::to_string(value); break; }
+                    case OperationalMode::AUTO:          { state = "auto";                break; }
+                    case OperationalMode::SECOND_HEATER: { state = "second_heater";       break; }
+                    case OperationalMode::PARTY:         { state = "party";               break; }
+                    case OperationalMode::VACATION:      { state = "vacation";            break; }
+                    case OperationalMode::OFF:           { state = "off";                 break; }
+                    default:                             { state = std::to_string(value); break; }
                 }
-                m_sensor_heating_mode->publish_state(text);
+
+                m_sensor_heating_mode.set_state(state);
             }
-#endif
 
             m_received_responses |= RESPONSE_HEATING_MODE;
 
@@ -1058,37 +800,36 @@ namespace esphome::luxtronik_v1
         {
             m_timer.cancel();
 
-            int32_t value = 0;
-            std::string text = "";
             size_t start = INDEX_RESPONSE_START;
             size_t end = response.find(DELIMITER, start);
             // skip number of elements
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-#ifdef USE_TEXT_SENSOR
-            if (m_sensor_hot_water_mode != nullptr)
+
+            if (m_sensor_hot_water_mode.has_sensor())
             {
-                value = std::atoi(response.substr(start, end - start).c_str());
+                std::string state = "";
+                int32_t value = get_number(response, start, end);
+
                 switch (static_cast<OperationalMode>(value))
                 {
-                    case OperationalMode::AUTO:          { text = "auto";                break; }
-                    case OperationalMode::SECOND_HEATER: { text = "second_heater";       break; }
-                    case OperationalMode::PARTY:         { text = "party";               break; }
-                    case OperationalMode::VACATION:      { text = "vacation";            break; }
-                    case OperationalMode::OFF:           { text = "off";                 break; }
-                    default:                             { text = std::to_string(value); break; }
+                    case OperationalMode::AUTO:          { state = "auto";                break; }
+                    case OperationalMode::SECOND_HEATER: { state = "second_heater";       break; }
+                    case OperationalMode::PARTY:         { state = "party";               break; }
+                    case OperationalMode::VACATION:      { state = "vacation";            break; }
+                    case OperationalMode::OFF:           { state = "off";                 break; }
+                    default:                             { state = std::to_string(value); break; }
                 }
-                m_sensor_hot_water_mode->publish_state(text);
+
+                m_sensor_hot_water_mode.set_state(state);
             }
-#endif
 
             m_received_responses |= RESPONSE_HOT_WATER_MODE;
         }
     }
 
-#ifdef USE_TEXT_SENSOR
-    void Luxtronik::parse_slot(const std::string& slot, text_sensor::TextSensor* sensor_code, text_sensor::TextSensor* sensor_time)
+    void Luxtronik::parse_slot(const std::string& slot, StringSensor& sensor_code, StringSensor& sensor_time)
     {
         size_t start = 0;
         size_t end = slot.find(DELIMITER, start);
@@ -1096,47 +837,41 @@ namespace esphome::luxtronik_v1
 
         start = end + 1;
         end = slot.find(DELIMITER, start);
-        if (sensor_code != nullptr)
+        sensor_code.set_state(slot, start, end);
+
+        if (sensor_time.has_sensor())
         {
-            sensor_code->
-                publish_state(
-                    slot.substr(start, end - start));
-        }
-
-        if (sensor_time != nullptr)
-        {
-            std::tm dt = {};
+            std::tm time = {};
 
             start = end + 1;
             end = slot.find(DELIMITER, start);
-            dt.tm_mday = get_number(slot.substr(start, end - start));
+            time.tm_mday = get_number(slot, start, end);
 
             start = end + 1;
             end = slot.find(DELIMITER, start);
-            dt.tm_mon = get_number(slot.substr(start, end - start)) - 1;  // convert from range 1-12 to range 0-11
+            time.tm_mon = get_number(slot, start, end) - 1;  // convert from range 1-12 to range 0-11
 
             start = end + 1;
             end = slot.find(DELIMITER, start);
-            dt.tm_year = get_number(slot.substr(start, end - start)) + 100;  // convert from years since 2000 to years since 1900
+            time.tm_year = get_number(slot, start, end) + 100;  // convert from years since 2000 to years since 1900
 
             start = end + 1;
             end = slot.find(DELIMITER, start);
-            dt.tm_hour = get_number(slot.substr(start, end - start));
+            time.tm_hour = get_number(slot, start, end);
 
             start = end + 1;
             end = slot.find(DELIMITER, start);
-            dt.tm_min = get_number(slot.substr(start, end - start));
+            time.tm_min = get_number(slot, start, end);
 
-            dt.tm_isdst = -1;  // auto-detect daylight saving time
-            std::mktime(&dt);  // convert to universal time
+            time.tm_isdst = -1;  // auto-detect daylight saving time
+            std::mktime(&time);  // convert to universal time
 
-            char timeStr[] = "yyyy-mm-ddThh:mm+zzzz";
-            std::strftime(timeStr, sizeof(timeStr), "%Y-%m-%dT%H:%M%z", &dt);
+            char state[] = "yyyy-mm-ddThh:mm+zzzz";
+            std::strftime(state, sizeof(state), "%Y-%m-%dT%H:%M%z", &time);
 
-            sensor_time->publish_state(timeStr);
+            sensor_time.set_state(state);
         }
     }
-#endif
 
     void Luxtronik::clear_uart_buffer()
     {

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -122,6 +122,7 @@ namespace esphome::luxtronik_v1
     private:
         void send_request(const char* req);
         void parse_response(const std::string& response);
+        void clear_uart_buffer();
 #ifdef USE_TEXT_SENSOR
         void parse_slot(const std::string& slot, text_sensor::TextSensor* sensor_code, text_sensor::TextSensor* sensor_time);
 #endif

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "luxtronik_sensor.h"
 #include "simple_timer.h"
 
 #include "esphome/core/defines.h"
@@ -41,6 +42,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/hal.h"
 
+#include <cstdint>
 #include <string>
 
 
@@ -56,73 +58,73 @@ namespace esphome::luxtronik_v1
             uint16_t max_retries);
         virtual ~Luxtronik() = default;
 
-        void loop() override;
         void update() override;
+        void loop() override;
 
         void dump_config() override;
 
 #ifdef USE_SENSOR
-        void set_sensor_flow_temperature(sensor::Sensor* sensor)                        { m_sensor_flow_temperature                = sensor; }
-        void set_sensor_return_temperature(sensor::Sensor* sensor)                      { m_sensor_return_temperature              = sensor; }
-        void set_sensor_return_set_temperature(sensor::Sensor* sensor)                  { m_sensor_return_set_temperature          = sensor; }
-        void set_sensor_hot_gas_temperature(sensor::Sensor* sensor)                     { m_sensor_hot_gas_temperature             = sensor; }
-        void set_sensor_outside_temperature(sensor::Sensor* sensor)                     { m_sensor_outside_temperature             = sensor; }
-        void set_sensor_hot_water_temperature(sensor::Sensor* sensor)                   { m_sensor_hot_water_temperature           = sensor; }
-        void set_sensor_hot_water_set_temperature(sensor::Sensor* sensor)               { m_sensor_hot_water_set_temperature       = sensor; }
-        void set_sensor_heat_source_input_temperature(sensor::Sensor* sensor)           { m_sensor_heat_source_input_temperature   = sensor; }
-        void set_sensor_heat_source_output_temperature(sensor::Sensor* sensor)          { m_sensor_heat_source_output_temperature  = sensor; }
-        void set_sensor_mixed_circuit_1_temperature(sensor::Sensor* sensor)             { m_sensor_mixed_circuit_1_temperature     = sensor; }
-        void set_sensor_mixed_circuit_1_set_temperature(sensor::Sensor* sensor)         { m_sensor_mixed_circuit_1_set_temperature = sensor; }
-        void set_sensor_remote_adjuster_temperature(sensor::Sensor* sensor)             { m_sensor_remote_adjuster_temperature     = sensor; }
+        void set_sensor_flow_temperature(sensor::Sensor* sensor)                        { m_sensor_flow_temperature.set_sensor(sensor);                }
+        void set_sensor_return_temperature(sensor::Sensor* sensor)                      { m_sensor_return_temperature.set_sensor(sensor);              }
+        void set_sensor_return_set_temperature(sensor::Sensor* sensor)                  { m_sensor_return_set_temperature.set_sensor(sensor);          }
+        void set_sensor_hot_gas_temperature(sensor::Sensor* sensor)                     { m_sensor_hot_gas_temperature.set_sensor(sensor);             }
+        void set_sensor_outside_temperature(sensor::Sensor* sensor)                     { m_sensor_outside_temperature.set_sensor(sensor);             }
+        void set_sensor_hot_water_temperature(sensor::Sensor* sensor)                   { m_sensor_hot_water_temperature.set_sensor(sensor);           }
+        void set_sensor_hot_water_set_temperature(sensor::Sensor* sensor)               { m_sensor_hot_water_set_temperature.set_sensor(sensor);       }
+        void set_sensor_heat_source_input_temperature(sensor::Sensor* sensor)           { m_sensor_heat_source_input_temperature.set_sensor(sensor);   }
+        void set_sensor_heat_source_output_temperature(sensor::Sensor* sensor)          { m_sensor_heat_source_output_temperature.set_sensor(sensor);  }
+        void set_sensor_mixed_circuit_1_temperature(sensor::Sensor* sensor)             { m_sensor_mixed_circuit_1_temperature.set_sensor(sensor);     }
+        void set_sensor_mixed_circuit_1_set_temperature(sensor::Sensor* sensor)         { m_sensor_mixed_circuit_1_set_temperature.set_sensor(sensor); }
+        void set_sensor_remote_adjuster_temperature(sensor::Sensor* sensor)             { m_sensor_remote_adjuster_temperature.set_sensor(sensor);     }
 #endif
 #ifdef USE_BINARY_SENSOR
-        void set_sensor_defrost_brine_flow(binary_sensor::BinarySensor* sensor)         { m_sensor_defrost_brine_flow              = sensor; }
-        void set_sensor_power_provider_lock_period(binary_sensor::BinarySensor* sensor) { m_sensor_power_provider_lock_period      = sensor; }
-        void set_sensor_high_pressure_state(binary_sensor::BinarySensor* sensor)        { m_sensor_high_pressure_state             = sensor; }
-        void set_sensor_engine_protection(binary_sensor::BinarySensor* sensor)          { m_sensor_engine_protection               = sensor; }
-        void set_sensor_low_pressure_state(binary_sensor::BinarySensor* sensor)         { m_sensor_low_pressure_state              = sensor; }
-        void set_sensor_external_power(binary_sensor::BinarySensor* sensor)             { m_sensor_external_power                  = sensor; }
-        void set_sensor_defrost_valve(binary_sensor::BinarySensor* sensor)              { m_sensor_defrost_valve                   = sensor; }
-        void set_sensor_hot_water_pump(binary_sensor::BinarySensor* sensor)             { m_sensor_hot_water_pump                  = sensor; }
-        void set_sensor_floor_heating_pump(binary_sensor::BinarySensor* sensor)         { m_sensor_floor_heating_pump              = sensor; }
-        void set_sensor_heating_pump(binary_sensor::BinarySensor* sensor)               { m_sensor_heating_pump                    = sensor; }
-        void set_sensor_housing_ventilation(binary_sensor::BinarySensor* sensor)        { m_sensor_housing_ventilation             = sensor; }
-        void set_sensor_ventilation_pump(binary_sensor::BinarySensor* sensor)           { m_sensor_ventilation_pump                = sensor; }
-        void set_sensor_compressor_1(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_1                    = sensor; }
-        void set_sensor_compressor_2(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_2                    = sensor; }
-        void set_sensor_extra_pump(binary_sensor::BinarySensor* sensor)                 { m_sensor_extra_pump                      = sensor; }
-        void set_sensor_secondary_heater_1(binary_sensor::BinarySensor* sensor)         { m_sensor_secondary_heater_1              = sensor; }
-        void set_sensor_secondary_heater_2_failure(binary_sensor::BinarySensor* sensor) { m_sensor_secondary_heater_2_failure      = sensor; }
-        void set_sensor_device_communication(binary_sensor::BinarySensor* sensor)       { m_sensor_device_communication            = sensor; }
+        void set_sensor_defrost_brine_flow(binary_sensor::BinarySensor* sensor)         { m_sensor_defrost_brine_flow.set_sensor(sensor);              }
+        void set_sensor_power_provider_lock_period(binary_sensor::BinarySensor* sensor) { m_sensor_power_provider_lock_period.set_sensor(sensor);      }
+        void set_sensor_high_pressure_state(binary_sensor::BinarySensor* sensor)        { m_sensor_high_pressure_state.set_sensor(sensor);             }
+        void set_sensor_engine_protection(binary_sensor::BinarySensor* sensor)          { m_sensor_engine_protection.set_sensor(sensor);               }
+        void set_sensor_low_pressure_state(binary_sensor::BinarySensor* sensor)         { m_sensor_low_pressure_state.set_sensor(sensor);              }
+        void set_sensor_external_power(binary_sensor::BinarySensor* sensor)             { m_sensor_external_power.set_sensor(sensor);                  }
+        void set_sensor_defrost_valve(binary_sensor::BinarySensor* sensor)              { m_sensor_defrost_valve.set_sensor(sensor);                   }
+        void set_sensor_hot_water_pump(binary_sensor::BinarySensor* sensor)             { m_sensor_hot_water_pump.set_sensor(sensor);                  }
+        void set_sensor_floor_heating_pump(binary_sensor::BinarySensor* sensor)         { m_sensor_floor_heating_pump.set_sensor(sensor);              }
+        void set_sensor_heating_pump(binary_sensor::BinarySensor* sensor)               { m_sensor_heating_pump.set_sensor(sensor);                    }
+        void set_sensor_housing_ventilation(binary_sensor::BinarySensor* sensor)        { m_sensor_housing_ventilation.set_sensor(sensor);             }
+        void set_sensor_ventilation_pump(binary_sensor::BinarySensor* sensor)           { m_sensor_ventilation_pump.set_sensor(sensor);                }
+        void set_sensor_compressor_1(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_1.set_sensor(sensor);                    }
+        void set_sensor_compressor_2(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_2.set_sensor(sensor);                    }
+        void set_sensor_extra_pump(binary_sensor::BinarySensor* sensor)                 { m_sensor_extra_pump.set_sensor(sensor);                      }
+        void set_sensor_secondary_heater_1(binary_sensor::BinarySensor* sensor)         { m_sensor_secondary_heater_1.set_sensor(sensor);              }
+        void set_sensor_secondary_heater_2_failure(binary_sensor::BinarySensor* sensor) { m_sensor_secondary_heater_2_failure.set_sensor(sensor);      }
+        void set_sensor_device_communication(binary_sensor::BinarySensor* sensor)       { m_sensor_device_communication.set_sensor(sensor);            }
 #endif
 #ifdef USE_TEXT_SENSOR
-        void set_sensor_mixer_1_state(text_sensor::TextSensor* sensor)                  { m_sensor_mixer_1_state                   = sensor; }
-        void set_sensor_device_type(text_sensor::TextSensor* sensor)                    { m_sensor_device_type                     = sensor; }
-        void set_sensor_firmware_version(text_sensor::TextSensor* sensor)               { m_sensor_firmware_version                = sensor; }
-        void set_sensor_bivalence_level(text_sensor::TextSensor* sensor)                { m_sensor_bivalence_level                 = sensor; }
-        void set_sensor_operational_state(text_sensor::TextSensor* sensor)              { m_sensor_operational_state               = sensor; }
-        void set_sensor_heating_mode(text_sensor::TextSensor* sensor)                   { m_sensor_heating_mode                    = sensor; }
-        void set_sensor_hot_water_mode(text_sensor::TextSensor* sensor)                 { m_sensor_hot_water_mode                  = sensor; }
-        void set_sensor_error_1_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_1_code                    = sensor; }
-        void set_sensor_error_2_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_2_code                    = sensor; }
-        void set_sensor_error_3_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_3_code                    = sensor; }
-        void set_sensor_error_4_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_4_code                    = sensor; }
-        void set_sensor_error_5_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_5_code                    = sensor; }
-        void set_sensor_error_1_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_1_time                    = sensor; }
-        void set_sensor_error_2_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_2_time                    = sensor; }
-        void set_sensor_error_3_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_3_time                    = sensor; }
-        void set_sensor_error_4_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_4_time                    = sensor; }
-        void set_sensor_error_5_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_5_time                    = sensor; }
-        void set_sensor_deactivation_1_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_1_code             = sensor; }
-        void set_sensor_deactivation_2_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_2_code             = sensor; }
-        void set_sensor_deactivation_3_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_code             = sensor; }
-        void set_sensor_deactivation_4_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_code             = sensor; }
-        void set_sensor_deactivation_5_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_code             = sensor; }
-        void set_sensor_deactivation_1_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_1_time             = sensor; }
-        void set_sensor_deactivation_2_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_2_time             = sensor; }
-        void set_sensor_deactivation_3_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_time             = sensor; }
-        void set_sensor_deactivation_4_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_time             = sensor; }
-        void set_sensor_deactivation_5_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_time             = sensor; }
+        void set_sensor_mixer_1_state(text_sensor::TextSensor* sensor)                  { m_sensor_mixer_1_state.set_sensor(sensor);                   }
+        void set_sensor_device_type(text_sensor::TextSensor* sensor)                    { m_sensor_device_type.set_sensor(sensor);                     }
+        void set_sensor_firmware_version(text_sensor::TextSensor* sensor)               { m_sensor_firmware_version.set_sensor(sensor);                }
+        void set_sensor_bivalence_level(text_sensor::TextSensor* sensor)                { m_sensor_bivalence_level.set_sensor(sensor);                 }
+        void set_sensor_operational_state(text_sensor::TextSensor* sensor)              { m_sensor_operational_state.set_sensor(sensor);               }
+        void set_sensor_heating_mode(text_sensor::TextSensor* sensor)                   { m_sensor_heating_mode.set_sensor(sensor);                    }
+        void set_sensor_hot_water_mode(text_sensor::TextSensor* sensor)                 { m_sensor_hot_water_mode.set_sensor(sensor);                  }
+        void set_sensor_error_1_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_1_code.set_sensor(sensor);                    }
+        void set_sensor_error_2_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_2_code.set_sensor(sensor);                    }
+        void set_sensor_error_3_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_3_code.set_sensor(sensor);                    }
+        void set_sensor_error_4_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_4_code.set_sensor(sensor);                    }
+        void set_sensor_error_5_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_5_code.set_sensor(sensor);                    }
+        void set_sensor_error_1_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_1_time.set_sensor(sensor);                    }
+        void set_sensor_error_2_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_2_time.set_sensor(sensor);                    }
+        void set_sensor_error_3_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_3_time.set_sensor(sensor);                    }
+        void set_sensor_error_4_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_4_time.set_sensor(sensor);                    }
+        void set_sensor_error_5_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_5_time.set_sensor(sensor);                    }
+        void set_sensor_deactivation_1_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_1_code.set_sensor(sensor);             }
+        void set_sensor_deactivation_2_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_2_code.set_sensor(sensor);             }
+        void set_sensor_deactivation_3_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_code.set_sensor(sensor);             }
+        void set_sensor_deactivation_4_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_code.set_sensor(sensor);             }
+        void set_sensor_deactivation_5_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_code.set_sensor(sensor);             }
+        void set_sensor_deactivation_1_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_1_time.set_sensor(sensor);             }
+        void set_sensor_deactivation_2_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_2_time.set_sensor(sensor);             }
+        void set_sensor_deactivation_3_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_time.set_sensor(sensor);             }
+        void set_sensor_deactivation_4_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_time.set_sensor(sensor);             }
+        void set_sensor_deactivation_5_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_time.set_sensor(sensor);             }
 #endif
 
     private:
@@ -132,98 +134,87 @@ namespace esphome::luxtronik_v1
         void parse_response(const std::string& response);
         void handle_timeout();
         void clear_uart_buffer();
-#ifdef USE_TEXT_SENSOR
-        void parse_slot(const std::string& slot, text_sensor::TextSensor* sensor_code, text_sensor::TextSensor* sensor_time);
-#endif
+        void parse_slot(const std::string& slot, StringSensor& sensor_code, StringSensor& sensor_time);
 
-        static float   get_temperature(const std::string& input_str)                { return std::atof(input_str.c_str()) / 10;          }
-        static int32_t get_number(const std::string& input_str)                     { return std::atoi(input_str.c_str());               }
-        static bool    get_binary_state(const std::string& input_str)               { return input_str != "0";                           }
-        static bool    starts_with(const std::string& str, const std::string& with) { return (str.compare(0, with.length(), with) == 0); }
+        static int32_t get_number(const std::string& input_str, uint16_t start, uint16_t end)       { return std::atoi(input_str.substr(start, end - start).c_str()); }
+        static bool    get_binary_state(const std::string& input_str, uint16_t start, uint16_t end) { return input_str.substr(start, end - start) != "0";             }
+        static bool    starts_with(const std::string& str, const std::string& with)                 { return (str.compare(0, with.length(), with) == 0);              }
 
     protected:
         uart::UARTDevice m_device;
 
-#ifdef USE_SENSOR
         // temperatures
-        sensor::Sensor* m_sensor_flow_temperature;                 // 1100:2  - Ist-Temperatur Vorlauf Heizkreis
-        sensor::Sensor* m_sensor_return_temperature;               // 1100:3  - Ist-Temperatur Rücklauf Heizkreis
-        sensor::Sensor* m_sensor_return_set_temperature;           // 1100:4  - Soll-Temperatur Rücklauf Heizkreis
-        sensor::Sensor* m_sensor_hot_gas_temperature;              // 1100:5  - Temperatur Heißgas
-        sensor::Sensor* m_sensor_outside_temperature;              // 1100:6  - Außentemperatur
-        sensor::Sensor* m_sensor_hot_water_temperature;            // 1100:7  - Ist-Temperatur Brauchwarmwasser
-        sensor::Sensor* m_sensor_hot_water_set_temperature;        // 1100:8  - Soll-Temperatur Brauchwarmwasser
-        sensor::Sensor* m_sensor_heat_source_input_temperature;    // 1100:9  - Temperatur Wärmequelleneintritt
-        sensor::Sensor* m_sensor_heat_source_output_temperature;   // 1100:10 - Temperatur Wärmequellenaustritt
-        sensor::Sensor* m_sensor_mixed_circuit_1_temperature;      // 1100:11 - Ist-Temperatur Vorlauf Mischkreis 1
-        sensor::Sensor* m_sensor_mixed_circuit_1_set_temperature;  // 1100:12 - Soll-Temperatur Vorlauf Mischkreis 1
-        sensor::Sensor* m_sensor_remote_adjuster_temperature;      // 1100:13 - Temperatur Raumfernversteller
-#endif
+        TemperatureSensor m_sensor_flow_temperature;                 // 1100:2  - Ist-Temperatur Vorlauf Heizkreis
+        TemperatureSensor m_sensor_return_temperature;               // 1100:3  - Ist-Temperatur Rücklauf Heizkreis
+        TemperatureSensor m_sensor_return_set_temperature;           // 1100:4  - Soll-Temperatur Rücklauf Heizkreis
+        TemperatureSensor m_sensor_hot_gas_temperature;              // 1100:5  - Temperatur Heißgas
+        TemperatureSensor m_sensor_outside_temperature;              // 1100:6  - Außentemperatur
+        TemperatureSensor m_sensor_hot_water_temperature;            // 1100:7  - Ist-Temperatur Brauchwarmwasser
+        TemperatureSensor m_sensor_hot_water_set_temperature;        // 1100:8  - Soll-Temperatur Brauchwarmwasser
+        TemperatureSensor m_sensor_heat_source_input_temperature;    // 1100:9  - Temperatur Wärmequelleneintritt
+        TemperatureSensor m_sensor_heat_source_output_temperature;   // 1100:10 - Temperatur Wärmequellenaustritt
+        TemperatureSensor m_sensor_mixed_circuit_1_temperature;      // 1100:11 - Ist-Temperatur Vorlauf Mischkreis 1
+        TemperatureSensor m_sensor_mixed_circuit_1_set_temperature;  // 1100:12 - Soll-Temperatur Vorlauf Mischkreis 1
+        TemperatureSensor m_sensor_remote_adjuster_temperature;      // 1100:13 - Temperatur Raumfernversteller
 
-#ifdef USE_BINARY_SENSOR
         // inputs
-        binary_sensor::BinarySensor* m_sensor_defrost_brine_flow;          // 1200:2 - Abtau, Soledruck, Durchfluss
-        binary_sensor::BinarySensor* m_sensor_power_provider_lock_period;  // 1200:3 - Sperrzeit EVU
-        binary_sensor::BinarySensor* m_sensor_high_pressure_state;         // 1200:4 - Hodruckpressostat
-        binary_sensor::BinarySensor* m_sensor_engine_protection;           // 1200:5 - Motorschutz
-        binary_sensor::BinarySensor* m_sensor_low_pressure_state;          // 1200:6 - Niederdruckpressostat
-        binary_sensor::BinarySensor* m_sensor_external_power;              // 1200:7 - Fremdstromanode
+        BoolSensor m_sensor_defrost_brine_flow;          // 1200:2 - Abtau, Soledruck, Durchfluss
+        BoolSensor m_sensor_power_provider_lock_period;  // 1200:3 - Sperrzeit EVU
+        BoolSensor m_sensor_high_pressure_state;         // 1200:4 - Hodruckpressostat
+        BoolSensor m_sensor_engine_protection;           // 1200:5 - Motorschutz
+        BoolSensor m_sensor_low_pressure_state;          // 1200:6 - Niederdruckpressostat
+        BoolSensor m_sensor_external_power;              // 1200:7 - Fremdstromanode
 
         // outputs
-        binary_sensor::BinarySensor* m_sensor_defrost_valve;               // 1300:2   - Abtauventil
-        binary_sensor::BinarySensor* m_sensor_hot_water_pump;              // 1300:3   - Brauchwarmwasserumwälzpumpe
-        binary_sensor::BinarySensor* m_sensor_floor_heating_pump;          // 1300:4   - Fußbodenheizungsumwälzpumpe
-        binary_sensor::BinarySensor* m_sensor_heating_pump;                // 1300:5   - Heizungsumwälzpumpe
-        binary_sensor::BinarySensor* m_sensor_housing_ventilation;         // 1300:8   - Ventilation Wärmepumpengehäuse
-        binary_sensor::BinarySensor* m_sensor_ventilation_pump;            // 1300:9   - Ventilator, Brunnen- oder Soleumwälzpumpe
-        binary_sensor::BinarySensor* m_sensor_compressor_1;                // 1300:10  - Verdichter 1 in Wärmepumpe
-        binary_sensor::BinarySensor* m_sensor_compressor_2;                // 1300:11  - Verdichter 2 in Wärmepumpe
-        binary_sensor::BinarySensor* m_sensor_extra_pump;                  // 1300:12  - Zusatzumwälzpumpe - Zirkulationspumpe
-        binary_sensor::BinarySensor* m_sensor_secondary_heater_1;          // 1300:13  - Zweiter Wärmeerzeuger 1
-        binary_sensor::BinarySensor* m_sensor_secondary_heater_2_failure;  // 1300:14  - Zweiter Wärmeerzeuger 2 - Sammelstörung
-
-        // diagnostic
-        binary_sensor::BinarySensor* m_sensor_device_communication;
-#endif
-
-#ifdef USE_TEXT_SENSOR
-        // outputs
-        text_sensor::TextSensor* m_sensor_mixer_1_state;  // 1300:6,7 - Mischer 1 fährt auf, Mischer 1 fährt zu
+        BoolSensor   m_sensor_defrost_valve;               // 1300:2   - Abtauventil
+        BoolSensor   m_sensor_hot_water_pump;              // 1300:3   - Brauchwarmwasserumwälzpumpe
+        BoolSensor   m_sensor_floor_heating_pump;          // 1300:4   - Fußbodenheizungsumwälzpumpe
+        BoolSensor   m_sensor_heating_pump;                // 1300:5   - Heizungsumwälzpumpe
+        StringSensor m_sensor_mixer_1_state;               // 1300:6,7 - Mischer 1 fährt auf, Mischer 1 fährt zu
+        BoolSensor   m_sensor_housing_ventilation;         // 1300:8   - Ventilation Wärmepumpengehäuse
+        BoolSensor   m_sensor_ventilation_pump;            // 1300:9   - Ventilator, Brunnen- oder Soleumwälzpumpe
+        BoolSensor   m_sensor_compressor_1;                // 1300:10  - Verdichter 1 in Wärmepumpe
+        BoolSensor   m_sensor_compressor_2;                // 1300:11  - Verdichter 2 in Wärmepumpe
+        BoolSensor   m_sensor_extra_pump;                  // 1300:12  - Zusatzumwälzpumpe - Zirkulationspumpe
+        BoolSensor   m_sensor_secondary_heater_1;          // 1300:13  - Zweiter Wärmeerzeuger 1
+        BoolSensor   m_sensor_secondary_heater_2_failure;  // 1300:14  - Zweiter Wärmeerzeuger 2 - Sammelstörung
 
         // information
-        text_sensor::TextSensor* m_sensor_device_type;        // 1700:2 - Wärmepumpentyp
-        text_sensor::TextSensor* m_sensor_firmware_version;   // 1700:3 - Software-Stand Firmware
-        text_sensor::TextSensor* m_sensor_bivalence_level;    // 1700:4 - Bivalenzstufe
-        text_sensor::TextSensor* m_sensor_operational_state;  // 1700:5 - Betriebszustand
+        StringSensor m_sensor_device_type;        // 1700:2 - Wärmepumpentyp
+        StringSensor m_sensor_firmware_version;   // 1700:3 - Software-Stand Firmware
+        StringSensor m_sensor_bivalence_level;    // 1700:4 - Bivalenzstufe
+        StringSensor m_sensor_operational_state;  // 1700:5 - Betriebszustand
 
         // modes
-        text_sensor::TextSensor* m_sensor_heating_mode;    // 3405:2 - Betriebsart Heizung
-        text_sensor::TextSensor* m_sensor_hot_water_mode;  // 3505:2 - Betriebsart Brauchwarmwasser
+        StringSensor m_sensor_heating_mode;    // 3405:2 - Betriebsart Heizung
+        StringSensor m_sensor_hot_water_mode;  // 3505:2 - Betriebsart Brauchwarmwasser
 
         // errors
-        text_sensor::TextSensor* m_sensor_error_1_code;  // 1500:1500:2   - Fehler 1 - Code
-        text_sensor::TextSensor* m_sensor_error_2_code;  // 1500:1501:2   - Fehler 2 - Code
-        text_sensor::TextSensor* m_sensor_error_3_code;  // 1500:1502:2   - Fehler 3 - Code
-        text_sensor::TextSensor* m_sensor_error_4_code;  // 1500:1503:2   - Fehler 4 - Code
-        text_sensor::TextSensor* m_sensor_error_5_code;  // 1500:1504:2   - Fehler 5 - Code
-        text_sensor::TextSensor* m_sensor_error_1_time;  // 1500:1500:2-6 - Fehler 1 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_error_2_time;  // 1500:1501:2-6 - Fehler 2 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_error_3_time;  // 1500:1502:2-6 - Fehler 3 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_error_4_time;  // 1500:1503:2-6 - Fehler 4 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_error_5_time;  // 1500:1504:2-6 - Fehler 5 - Datum/Uhrzeit
+        StringSensor m_sensor_error_1_code;  // 1500:1500:2   - Fehler 1 - Code
+        StringSensor m_sensor_error_2_code;  // 1500:1501:2   - Fehler 2 - Code
+        StringSensor m_sensor_error_3_code;  // 1500:1502:2   - Fehler 3 - Code
+        StringSensor m_sensor_error_4_code;  // 1500:1503:2   - Fehler 4 - Code
+        StringSensor m_sensor_error_5_code;  // 1500:1504:2   - Fehler 5 - Code
+        StringSensor m_sensor_error_1_time;  // 1500:1500:2-6 - Fehler 1 - Datum/Uhrzeit
+        StringSensor m_sensor_error_2_time;  // 1500:1501:2-6 - Fehler 2 - Datum/Uhrzeit
+        StringSensor m_sensor_error_3_time;  // 1500:1502:2-6 - Fehler 3 - Datum/Uhrzeit
+        StringSensor m_sensor_error_4_time;  // 1500:1503:2-6 - Fehler 4 - Datum/Uhrzeit
+        StringSensor m_sensor_error_5_time;  // 1500:1504:2-6 - Fehler 5 - Datum/Uhrzeit
 
         // deactivations
-        text_sensor::TextSensor* m_sensor_deactivation_1_code;  // 1600:1600:2   - Abschaltung 1 - Code
-        text_sensor::TextSensor* m_sensor_deactivation_2_code;  // 1600:1601:2   - Abschaltung 2 - Code
-        text_sensor::TextSensor* m_sensor_deactivation_3_code;  // 1600:1602:2   - Abschaltung 3 - Code
-        text_sensor::TextSensor* m_sensor_deactivation_4_code;  // 1600:1603:2   - Abschaltung 4 - Code
-        text_sensor::TextSensor* m_sensor_deactivation_5_code;  // 1600:1604:2   - Abschaltung 5 - Code
-        text_sensor::TextSensor* m_sensor_deactivation_1_time;  // 1600:1600:2-6 - Abschaltung 1 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_deactivation_2_time;  // 1600:1601:2-6 - Abschaltung 2 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_deactivation_3_time;  // 1600:1602:2-6 - Abschaltung 3 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_deactivation_4_time;  // 1600:1603:2-6 - Abschaltung 4 - Datum/Uhrzeit
-        text_sensor::TextSensor* m_sensor_deactivation_5_time;  // 1600:1604:2-6 - Abschaltung 5 - Datum/Uhrzeit
-#endif
+        StringSensor m_sensor_deactivation_1_code;  // 1600:1600:2   - Abschaltung 1 - Code
+        StringSensor m_sensor_deactivation_2_code;  // 1600:1601:2   - Abschaltung 2 - Code
+        StringSensor m_sensor_deactivation_3_code;  // 1600:1602:2   - Abschaltung 3 - Code
+        StringSensor m_sensor_deactivation_4_code;  // 1600:1603:2   - Abschaltung 4 - Code
+        StringSensor m_sensor_deactivation_5_code;  // 1600:1604:2   - Abschaltung 5 - Code
+        StringSensor m_sensor_deactivation_1_time;  // 1600:1600:2-6 - Abschaltung 1 - Datum/Uhrzeit
+        StringSensor m_sensor_deactivation_2_time;  // 1600:1601:2-6 - Abschaltung 2 - Datum/Uhrzeit
+        StringSensor m_sensor_deactivation_3_time;  // 1600:1602:2-6 - Abschaltung 3 - Datum/Uhrzeit
+        StringSensor m_sensor_deactivation_4_time;  // 1600:1603:2-6 - Abschaltung 4 - Datum/Uhrzeit
+        StringSensor m_sensor_deactivation_5_time;  // 1600:1604:2-6 - Abschaltung 5 - Datum/Uhrzeit
+
+        // diagnostic
+        BoolSensor m_sensor_device_communication;
 
         // configuration
         uint16_t m_request_delay;

--- a/components/luxtronik_v1/luxtronik_sensor.h
+++ b/components/luxtronik_v1/luxtronik_sensor.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2024 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include "esphome/core/defines.h"
+#include "esphome/core/component.h"
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
+#include <cstdint>
+#include <string>
+
+
+namespace esphome::luxtronik_v1
+{
+    class TemperatureSensor
+    {
+    public:
+        TemperatureSensor()
+#ifdef USE_SENSOR
+            : m_sensor(nullptr)
+#endif
+        {
+        }
+
+        void set_state(const std::string& input_str, uint16_t start, uint16_t end)
+        {
+#ifdef USE_SENSOR
+            if (m_sensor != nullptr)
+            {
+                m_sensor->publish_state(
+                            static_cast<float>(
+                                std::atoi(input_str.substr(start, end - start).c_str())) / 10);
+            }
+#endif
+        }
+
+#ifdef USE_SENSOR
+        void set_sensor(sensor::Sensor* sensor) { m_sensor = sensor; }
+        sensor::Sensor* get_sensor() { return m_sensor; }
+#endif
+
+    private:
+#ifdef USE_SENSOR
+        sensor::Sensor* m_sensor;
+#endif
+    };
+
+    class StringSensor
+    {
+    public:
+        StringSensor()
+#ifdef USE_TEXT_SENSOR
+            : m_sensor(nullptr)
+#endif
+        {
+        }
+
+        void set_state(const std::string& input_str)
+        {
+#ifdef USE_TEXT_SENSOR
+            if (m_sensor != nullptr)
+            {
+                m_sensor->publish_state(input_str);
+            }
+#endif
+        }
+
+        void set_state(const std::string& input_str, uint16_t start, uint16_t end)
+        {
+#ifdef USE_TEXT_SENSOR
+            if (m_sensor != nullptr)
+            {
+                m_sensor->publish_state(input_str.substr(start, end - start));
+            }
+#endif
+        }
+
+        bool has_sensor()
+        {
+#ifdef USE_TEXT_SENSOR
+            return m_sensor != nullptr;
+#else
+            return false;
+#endif
+        }
+
+#ifdef USE_TEXT_SENSOR
+        void set_sensor(text_sensor::TextSensor* sensor) { m_sensor = sensor; }
+        text_sensor::TextSensor* get_sensor() { return m_sensor; }
+#endif
+
+    protected:
+#ifdef USE_TEXT_SENSOR
+        text_sensor::TextSensor* m_sensor;
+#endif
+    };
+
+    class BoolSensor
+    {
+    public:
+        BoolSensor()
+#ifdef USE_BINARY_SENSOR
+            : m_sensor(nullptr)
+#endif
+        {
+        }
+
+        void set_state(const std::string& input_str, uint16_t start, uint16_t end, bool invert = false)
+        {
+#ifdef USE_BINARY_SENSOR
+            if (m_sensor != nullptr)
+            {
+                std::string part = input_str.substr(start, end - start);
+                m_sensor->publish_state(invert ? (part == "0") : (part != "0"));
+            }
+#endif
+        }
+
+        void set_state(bool state)
+        {
+#ifdef USE_BINARY_SENSOR
+            if (m_sensor != nullptr)
+            {
+                m_sensor->publish_state(state);
+            }
+#endif
+        }
+
+#ifdef USE_BINARY_SENSOR
+        void set_sensor(binary_sensor::BinarySensor* sensor) { m_sensor = sensor; }
+        binary_sensor::BinarySensor* get_sensor() { return m_sensor; }
+#endif
+
+    private:
+#ifdef USE_BINARY_SENSOR
+        binary_sensor::BinarySensor* m_sensor;
+#endif
+    };
+}  // namespace esphome::luxtronik_v1

--- a/components/luxtronik_v1/simple_timer.h
+++ b/components/luxtronik_v1/simple_timer.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+
+
+namespace esphome::luxtronik_v1
+{
+    class SimpleTimer
+    {
+    public:
+        using Callback = std::function<void()>;
+
+        SimpleTimer()
+            : m_running(false)
+            , m_start_time()
+            , m_duration()
+            , m_callback()
+        {
+        }
+
+        template<class R, class P>
+        void schedule(const std::chrono::duration<R, P>& duration, Callback&& cb)
+        {
+            m_start_time = std::chrono::steady_clock::now();
+            m_duration = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+            m_callback = std::move(cb);
+
+            m_running = true;
+        }
+
+        void cancel()
+        {
+            m_running = false;
+        }
+
+        void loop()
+        {
+            if (m_running)
+            {
+                auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                            std::chrono::steady_clock::now() - m_start_time);
+
+                if (diff >= m_duration)
+                {
+                    m_running = false;
+
+                    Callback cb = std::move(m_callback);
+                    cb();  // do not call m_callback directly as it might be reassigned during call
+                }
+            }
+        }
+
+    private:
+        bool m_running;
+        std::chrono::time_point<std::chrono::steady_clock> m_start_time;
+        std::chrono::milliseconds m_duration;
+        Callback m_callback;
+    };
+}  // namespace esphome::luxtronik_v1


### PR DESCRIPTION
This pull request adds a couple of robustness improvement measures in order to mitigate the problems with the UART communication as far as possible.

These measures include:
- Clear the UART RX buffer before sending new requests to ensure that there is no junk data in the buffer when receiving responses from the Luxtronik heating control unit.
- Add configurable delay between requests sent to the Luxtronik heating control unit (but set to 0 by default).
- Perform retries if a response is not received within a specific amount of time (timeout and maximum number of retries are configurable).