### PR TITLE
Add support for data set 1450

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Die folgenden generischen Einstellungen können konfiguriert werden:
 | `request_delay` | nein | Zahl | 0 - 2000 | 0 | Verzögerung in Millisekunden zwischen einzelnen Datensatz-Anfragen |
 | `response_timeout` | nein | Zahl | 500 - 5000 | 2000 | Maximale Zeit in Millisekunden, die nach einer Datensatz-Anfrage auf die Antwort gewartet wird, bevor ein Wiederholungsversuch gestartet wird |
 | `max_retries` | nein | Zahl | 0 - 15 | 5 | Maximale Anzahl an Wiederholungsversuchen, bevor mit der nächsten Datensatz-Anfrage fortgefahren wird |
-| `include_datasets` | nein | Zahlenliste | 1100, 1200, 1300, 1500, 1600, 1700, 3405, 3505 | Alle | Datensätze, die angefragt werden sollen <sup>1</sup> |
+| `include_datasets` | nein | Zahlenliste | 1100, 1200, 1300, 1450, 1500, 1600, 1700, 3405, 3505 | Alle | Datensätze, die angefragt werden sollen <sup>1</sup> |
 
 <sup>1</sup> Es sollte sicher gestellt sein, dass keine Sensoren von ausgelassenen Datensätzen konfiguriert sind, da diese anderenfalls keine Werte erhalten werden. Siehe Abschnitt [Sensoren](#sensoren) um mehr darüber zu erfahren, welche Sensoren in welchen Datensätzen enthalten sind.
 
@@ -102,6 +102,7 @@ luxtronik_v1:
     - 1100
     - 1200
     - 1300
+    - 1450
     - 1700
     - 3405
     - 3505
@@ -195,6 +196,8 @@ Die folgenden numerischen Sensoren können konfiguriert werden:
 | `mixed_circuit_1_temperature` | `temperature` | 1100 |  Ist-Temperatur Vorlauf Mischkreis 1 |
 | `mixed_circuit_1_set_temperature` | `temperature` | 1100 |  Soll-Temperatur Vorlauf Mischkreis 1 |
 | `remote_adjuster_temperature` | `temperature` | 1100 |  Temperatur Raumfernversteller |
+| `impulses_compressor_1` | - | 1450 |  Impulse Verdichter 1 |
+| `impulses_compressor_2` | - | 1450 |  Impulse Verdichter 2 |
 
 Detaillierte Informationen zu den Konfigurationsmöglichkeiten der einzelnen Elemente findest du in der Dokumentation der [ESPHome Sensorkomponenten](https://www.esphome.io/components/sensor).
 
@@ -271,6 +274,13 @@ Die folgenden Textsensoren können konfiguriert werden:
 | `heating_mode` | - | 3405 | Betriebsart Heizung |
 | `hot_water_mode` | - | 3505 | Betriebsart Brauchwarmwasser |
 | `mixer_1_state` | - | 1300 | Zustand Mischer 1 |
+| `operating_hours_compressor_1` | - | 1450 | Betriebsstunden Verdichter 1 |
+| `average_operating_time_compressor_1` | - | 1450 | Durchschnittliche Laufzeit Verdichter 1 |
+| `operating_hours_compressor_2` | - | 1450 | Betriebsstunden Verdichter 2 |
+| `average_operating_time_compressor_2` | - | 1450 | Durchschnittliche Laufzeit Verdichter 2 |
+| `operating_hours_secondary_heater_1` | - | 1450 | Betriebsstunden Zweiter Wärmeerzeuger 1 |
+| `operating_hours_secondary_heater_2` | - | 1450 | Betriebsstunden Zweiter Wärmeerzeuger 2 |
+| `operating_hours_heat_pump` | - | 1450 | Betriebsstunden Wärmepumpe |
 | `error_1_code` | - | 1500 | Fehler-Code #1 im Fehlerspreicher (ältester) |
 | `error_1_time` | `timestamp` | 1500 | Fehlerzeitpunkt #1 im Fehlerspeicher (ältester) |
 | `error_2_code` | - | 1500 | Fehler-Code #2 im Fehlerspreicher |
@@ -345,6 +355,16 @@ Die Sensoren `heating_mode` und `hot_water_mode` bieten die folgenden Werte:
 | `vacation` | Ferien |
 | `off` | Aus |
 
+Die Sensoren `operating_hours_compressor_1`, `average_operating_time_compressor_1`, `operating_hours_compressor_2`, `average_operating_time_compressor_2`, `operating_hours_secondary_heater_1`, `operating_hours_secondary_heater_2` und `operating_hours_heat_pump`
+unterstützen das zusätzliche Konfigurationselement `duration_format`, mit dem angegeben werden kann, wie die Zeitspanne im Sensor formatiert wird. Das Konfigurationselement kann folgende Werte annehmen:
+
+| Wert | Beschreibung |
+| ---- | ------------ |
+| `iso_8601` | Die Zeitspanne wird als Zeichenkette mit einer Dauer nach ISO-8601 formatiert |
+| `human_readable` | Die Zeitspanne wird als visuell lesbare Zeichenkette mit durch Doppelpunkte getrennte Stunden, Minuten und Sekunden formatiert |
+
+Wenn das Konfigurationselement weggelassen wird, wird der Wert `human_readable` verwendet.
+
 ##### Beispiel
 ```yaml
 text_sensor:
@@ -373,6 +393,20 @@ text_sensor:
           - defrost -> Abtauen
           - swimming_pool -> Schwimmbad
           - provider_lock -> EVU-Sperre
+    operating_hours_compressor_1:
+      name: Betriebsstunden Verdichter
+      duration_format: iso_8601
+    average_operating_time_compressor_1:
+      name: Durchschnittliche Laufzeit Verdichter
+      duration_format: iso_8601
+    error_5_code:
+      name: Letzter Fehler - Code
+    error_5_time:
+      name: Letzter Fehler - Zeit
+    deactivation_5_code:
+      name: Letzte Abschaltung - Code
+    deactivation_5_time:
+      name: Letzte Abschaltung - Zeit
 ```
 
 ## Luxtronik-Konfiguration
@@ -465,7 +499,7 @@ The following generic configuration items can be configured:
 | `request_delay` | no | Number | 0 - 2000 | 0 | Delay in milliseconds between individual dataset requests |
 | `response_timeout` | no | Number | 500 - 5000 | 2000 | Maximum time in milliseconds to wait for a response after a dataset request before a retry is done |
 | `max_retries` | no | Number | 0 - 15 | 5 | Maximum number of retries before proceeding with next dataset request |
-| `include_datasets` | no | List of numbers | 1100, 1200, 1300, 1500, 1600, 1700, 3405, 3505 | All | Data sets which should be requested <sup>1</sup> |
+| `include_datasets` | no | List of numbers | 1100, 1200, 1300, 1450, 1500, 1600, 1700, 3405, 3505 | All | Data sets which should be requested <sup>1</sup> |
 
 <sup>1</sup> It should be ensured that no sensors from omitted data sets are configured, otherwise they will not receive any values. See section [Sensors](#sensors) to find out more about which sensors are contained in which data sets.
 
@@ -481,6 +515,7 @@ luxtronik_v1:
     - 1100
     - 1200
     - 1300
+    - 1450
     - 1700
     - 3405
     - 3505
@@ -574,6 +609,8 @@ The following numeric sensors can be configured:
 | `mixed_circuit_1_temperature` | `temperature` | 1100 | Temperature of mixed circuit 1 |
 | `mixed_circuit_1_set_temperature` | `temperature` | 1100 | Set-emperature of mixed circuit 1 |
 | `remote_adjuster_temperature` | `temperature` | 1100 | Temperature of the remote adjuster |
+| `impulses_compressor_1` | - | 1450 |  Number of impulses of compressor 1 |
+| `impulses_compressor_2` | - | 1450 |  Number of impulses of compressor 2 |
 
 For detailed configuration options of each item, please refer to ESPHome [sensor component configuration](https://www.esphome.io/components/sensor).
 
@@ -650,6 +687,13 @@ The following text sensors can be configured:
 | `heating_mode` | - | 3405 | Heating mode |
 | `hot_water_mode` | - | 3505 | Hot water mode |
 | `mixer_1_state` | - | 1300 | State of mixer 1 |
+| `operating_hours_compressor_1` | - | 1450 | Operating hours of compressor 1 |
+| `average_operating_time_compressor_1` | - | 1450 | Average operating time of compressor 1 |
+| `operating_hours_compressor_2` | - | 1450 | Operating hours of compressor 2 |
+| `average_operating_time_compressor_2` | - | 1450 | Average operating time of compressor 2 |
+| `operating_hours_secondary_heater_1` | - | 1450 | Operating hours of secondary heater 1 |
+| `operating_hours_secondary_heater_2` | - | 1450 | Operating hours of secondary heater 2 |
+| `operating_hours_heat_pump` | - | 1450 | Operating hours of heat pump |
 | `error_1_code` | - | 1500 | Error code #1 in error memory (oldest) |
 | `error_1_time` | `timestamp` | 1500 | Error timestamp #1 in error memory (oldest) |
 | `error_2_code` | - | 1500 | Error code #2 in error memory |
@@ -724,6 +768,15 @@ The sensors `heating_mode` and `hot_water_mode` provide the following values:
 | `vacation` | Vacation mode |
 | `off` | Off |
 
+The sensors `operating_hours_compressor_1`, `average_operating_time_compressor_1`, `operating_hours_compressor_2`, `average_operating_time_compressor_2`, `operating_hours_secondary_heater_1`, `operating_hours_secondary_heater_2` and `operating_hours_heat_pump` support the additional configuration item `duration_format` which specifies how the time period is formatted in the sensor. The configuration item can take the following values:
+
+| Value | Description |
+| ---- | ------------ |
+| `iso_8601` | Time period is formatted as ISO-8601 duration string |
+| `human_readable` | Time period is formatted as a human readable string with hours, minutes and seconds separated by colons |
+
+If the configuration item is omitted, it defaults to `human_readable`.
+
 ##### Example
 ```yaml
 text_sensor:
@@ -752,6 +805,20 @@ text_sensor:
           - defrost -> Abtauen
           - swimming_pool -> Schwimmbad
           - provider_lock -> EVU-Sperre
+    operating_hours_compressor_1:
+      name: Betriebsstunden Verdichter
+      duration_format: iso_8601
+    average_operating_time_compressor_1:
+      name: Durchschnittliche Laufzeit Verdichter
+      duration_format: iso_8601
+    error_5_code:
+      name: Letzter Fehler - Code
+    error_5_time:
+      name: Letzter Fehler - Zeit
+    deactivation_5_code:
+      name: Letzte Abschaltung - Code
+    deactivation_5_time:
+      name: Letzte Abschaltung - Zeit
 ```
 
 ## Luxtronik Configuration

--- a/components/luxtronik_v1/__init__.py
+++ b/components/luxtronik_v1/__init__.py
@@ -57,9 +57,9 @@ CONFIG_SCHEMA = cv.Schema(
     cv.Optional(CONF_MAX_RETRIES, default = 5): cv.int_range(min = 0, max = 15),
     cv.Optional(
         CONF_INCLUDE_DATASETS,
-        default = [1100, 1200, 1300, 1500, 1600, 1700, 3405, 3505]):
+        default = [1100, 1200, 1300, 1450, 1500, 1600, 1700, 3405, 3505]):
         cv.All(
-            cv.ensure_list(cv.one_of(1100, 1200, 1300, 1500, 1600, 1700, 3405, 3505)),
+            cv.ensure_list(cv.one_of(1100, 1200, 1300, 1450, 1500, 1600, 1700, 3405, 3505)),
             cv.Length(min = 1),
             unique_list)
 }).extend(uart.UART_DEVICE_SCHEMA).extend(cv.polling_component_schema("60s"))

--- a/components/luxtronik_v1/binary_sensor.py
+++ b/components/luxtronik_v1/binary_sensor.py
@@ -63,68 +63,68 @@ CONFIG_SCHEMA = cv.Schema(
 {
     cv.GenerateID(CONF_LUXTRONIK_ID): cv.use_id(Luxtronik),
     cv.Optional(CONF_DEFROST_BRINE_FLOW): binary_sensor.binary_sensor_schema(
-        icon="mdi:snowflake-off"
+        icon = "mdi:snowflake-off"
     ),
     cv.Optional(CONF_POWER_PROVIDER_LOCK_PERIOD): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_LOCK
+        device_class = DEVICE_CLASS_LOCK
     ),
     cv.Optional(CONF_LOW_PRESSURE_STATE): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_PROBLEM
+        device_class = DEVICE_CLASS_PROBLEM
     ),
     cv.Optional(CONF_HIGH_PRESSURE_STATE): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_PROBLEM
+        device_class = DEVICE_CLASS_PROBLEM
     ),
     cv.Optional(CONF_ENGINE_PROTECTION): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_PROBLEM
+        device_class = DEVICE_CLASS_PROBLEM
     ),
     cv.Optional(CONF_EXTERNAL_POWER): binary_sensor.binary_sensor_schema(
-        icon="mdi:transmission-tower"
+        icon = "mdi:transmission-tower"
     ),
     cv.Optional(CONF_DEFROST_VALVE): binary_sensor.binary_sensor_schema(
-        icon="mdi:pipe-valve"
+        icon = "mdi:pipe-valve"
     ),
     cv.Optional(CONF_HOT_WATER_PUMP): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:pump"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:pump"
     ),
     cv.Optional(CONF_HEATING_PUMP): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:pump"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:pump"
     ),
     cv.Optional(CONF_FLOOR_HEATING_PUMP): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:pump"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:pump"
     ),
     cv.Optional(CONF_VENTILATION_HOUSING): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:fan"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:fan"
     ),
     cv.Optional(CONF_VENTILATION_PUMP): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:fan"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:fan"
     ),
     cv.Optional(CONF_COMPRESSOR_1): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:engine"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:engine"
     ),
     cv.Optional(CONF_COMPRESSOR_2): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:engine"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:engine"
     ),
     cv.Optional(CONF_EXTRA_PUMP): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:pump"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:pump"
     ),
     cv.Optional(CONF_SECONDARY_HEATER_1): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_RUNNING,
-        icon="mdi:heating-coil"
+        device_class = DEVICE_CLASS_RUNNING,
+        icon = "mdi:heating-coil"
     ),
     cv.Optional(CONF_SECONDARY_HEATER_2_FAILURE): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_PROBLEM
+        device_class = DEVICE_CLASS_PROBLEM
     ),
     cv.Optional(CONF_DEVICE_COMMUNICATION): binary_sensor.binary_sensor_schema(
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        device_class=DEVICE_CLASS_PROBLEM
+        entity_category = ENTITY_CATEGORY_DIAGNOSTIC,
+        device_class = DEVICE_CLASS_PROBLEM
     )
 })
 

--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -37,6 +37,7 @@ namespace esphome::luxtronik_v1
     static constexpr const char* const TYPE_TEMPERATURES       = "1100";
     static constexpr const char* const TYPE_INPUTS             = "1200";
     static constexpr const char* const TYPE_OUTPUTS            = "1300";
+    static constexpr const char* const TYPE_OPERATING_HOURS    = "1450";
     static constexpr const char* const TYPE_ERRORS             = "1500";
     static constexpr const char* const TYPE_ERRORS_SLOT        = "1500;150";
     static constexpr const char* const TYPE_DEACTIVATIONS      = "1600";
@@ -153,6 +154,15 @@ namespace esphome::luxtronik_v1
         , m_sensor_operational_state()
         , m_sensor_heating_mode()
         , m_sensor_hot_water_mode()
+        , m_sensor_operating_hours_compressor_1()
+        , m_sensor_impulses_compressor_1()
+        , m_sensor_average_operating_time_compressor_1()
+        , m_sensor_operating_hours_compressor_2()
+        , m_sensor_impulses_compressor_2()
+        , m_sensor_average_operating_time_compressor_2()
+        , m_sensor_operating_hours_secondary_heater_1()
+        , m_sensor_operating_hours_secondary_heater_2()
+        , m_sensor_operating_hours_heat_pump()
         , m_sensor_error_1_code()
         , m_sensor_error_2_code()
         , m_sensor_error_3_code()
@@ -293,69 +303,75 @@ namespace esphome::luxtronik_v1
         ESP_LOGCONFIG(TAG, "  Response timeout: %u", m_response_timeout);
         ESP_LOGCONFIG(TAG, "  Max. number of retries: %u", m_max_retries);
 
-#ifdef USE_SENSOR
-        LOG_SENSOR("", "Flow Temperture Sensor", m_sensor_flow_temperature.get_sensor());
-        LOG_SENSOR("", "Return Temperture Sensor", m_sensor_return_temperature.get_sensor());
-        LOG_SENSOR("", "Return Set-Temperture Sensor", m_sensor_return_set_temperature.get_sensor());
-        LOG_SENSOR("", "Hot Gas Temperture Sensor", m_sensor_hot_gas_temperature.get_sensor());
-        LOG_SENSOR("", "Hot Water Temperture Sensor", m_sensor_hot_water_temperature.get_sensor());
-        LOG_SENSOR("", "Hot Water Set-Temperture Sensor", m_sensor_hot_water_set_temperature.get_sensor());
-        LOG_SENSOR("", "Outside Temperture Sensor", m_sensor_outside_temperature.get_sensor());
-        LOG_SENSOR("", "Heat-Source Input Temperture Sensor", m_sensor_heat_source_input_temperature.get_sensor());
-        LOG_SENSOR("", "Heat-Source Output Temperture Sensor", m_sensor_heat_source_output_temperature.get_sensor());
-        LOG_SENSOR("", "Mixed Circuit 1 Temperture Sensor", m_sensor_mixed_circuit_1_temperature.get_sensor());
-        LOG_SENSOR("", "Mixed Circuit 1 Set-Temperture Sensor", m_sensor_mixed_circuit_1_set_temperature.get_sensor());
-        LOG_SENSOR("", "Remote Adjuster Temperture Sensor", m_sensor_remote_adjuster_temperature.get_sensor());
-#endif
+        LOG_TEMPERATURE_SENSOR("Flow Temperture Sensor", m_sensor_flow_temperature);
+        LOG_TEMPERATURE_SENSOR("Return Temperture Sensor", m_sensor_return_temperature);
+        LOG_TEMPERATURE_SENSOR("Return Set-Temperture Sensor", m_sensor_return_set_temperature);
+        LOG_TEMPERATURE_SENSOR("Hot Gas Temperture Sensor", m_sensor_hot_gas_temperature);
+        LOG_TEMPERATURE_SENSOR("Hot Water Temperture Sensor", m_sensor_hot_water_temperature);
+        LOG_TEMPERATURE_SENSOR("Hot Water Set-Temperture Sensor", m_sensor_hot_water_set_temperature);
+        LOG_TEMPERATURE_SENSOR("Outside Temperture Sensor", m_sensor_outside_temperature);
+        LOG_TEMPERATURE_SENSOR("Heat-Source Input Temperture Sensor", m_sensor_heat_source_input_temperature);
+        LOG_TEMPERATURE_SENSOR("Heat-Source Output Temperture Sensor", m_sensor_heat_source_output_temperature);
+        LOG_TEMPERATURE_SENSOR("Mixed Circuit 1 Temperture Sensor", m_sensor_mixed_circuit_1_temperature);
+        LOG_TEMPERATURE_SENSOR("Mixed Circuit 1 Set-Temperture Sensor", m_sensor_mixed_circuit_1_set_temperature);
+        LOG_TEMPERATURE_SENSOR("Remote Adjuster Temperture Sensor", m_sensor_remote_adjuster_temperature);
 
-#ifdef USE_BINARY_SENSOR
-        LOG_BINARY_SENSOR("", "Defrost/Brine/Flow Sensor", m_sensor_defrost_brine_flow.get_sensor());
-        LOG_BINARY_SENSOR("", "Power Provider Lock Period Sensor", m_sensor_power_provider_lock_period.get_sensor());
-        LOG_BINARY_SENSOR("", "Low Pressure State Sensor", m_sensor_low_pressure_state.get_sensor());
-        LOG_BINARY_SENSOR("", "High Pressure State Sensor", m_sensor_high_pressure_state.get_sensor());
-        LOG_BINARY_SENSOR("", "Engine Protection Sensor", m_sensor_engine_protection.get_sensor());
-        LOG_BINARY_SENSOR("", "External Power Sensor", m_sensor_external_power.get_sensor());
-        LOG_BINARY_SENSOR("", "Defrost Valve Sensor", m_sensor_defrost_valve.get_sensor());
-        LOG_BINARY_SENSOR("", "Hot Water Pump Sensor", m_sensor_hot_water_pump.get_sensor());
-        LOG_BINARY_SENSOR("", "Heating Pump Sensor", m_sensor_heating_pump.get_sensor());
-        LOG_BINARY_SENSOR("", "Floor Heating Pump Sensor", m_sensor_floor_heating_pump.get_sensor());
-        LOG_BINARY_SENSOR("", "Ventilation/Pump Sensor", m_sensor_ventilation_pump.get_sensor());
-        LOG_BINARY_SENSOR("", "Housing Ventilation Sensor", m_sensor_housing_ventilation.get_sensor());
-        LOG_BINARY_SENSOR("", "Compressor 1 Sensor", m_sensor_compressor_1.get_sensor());
-        LOG_BINARY_SENSOR("", "Compressor 2 Sensor", m_sensor_compressor_2.get_sensor());
-        LOG_BINARY_SENSOR("", "Extra Pump Sensor", m_sensor_extra_pump.get_sensor());
-        LOG_BINARY_SENSOR("", "Secondary Heater 1 Sensor", m_sensor_secondary_heater_1.get_sensor());
-        LOG_BINARY_SENSOR("", "Secondary Heater 2 Failure Sensor", m_sensor_secondary_heater_2_failure.get_sensor());
-        LOG_BINARY_SENSOR("", "Device Communication Sensor", m_sensor_device_communication.get_sensor());
-#endif
+        LOG_NUMERIC_SENSOR("Impulses Compressor 1 Sensor", m_sensor_impulses_compressor_1);
+        LOG_NUMERIC_SENSOR("Impulses Compressor 2 Sensor", m_sensor_impulses_compressor_2);
 
-#ifdef USE_TEXT_SENSOR
-        LOG_TEXT_SENSOR("", "Mixer 1 Sensor", m_sensor_mixer_1_state.get_sensor());
-        LOG_TEXT_SENSOR("", "Device Type Sensor", m_sensor_device_type.get_sensor());
-        LOG_TEXT_SENSOR("", "Firmware Version Sensor", m_sensor_firmware_version.get_sensor());
-        LOG_TEXT_SENSOR("", "Bivalence Level Sensor", m_sensor_bivalence_level.get_sensor());
-        LOG_TEXT_SENSOR("", "Operational State Sensor", m_sensor_operational_state.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 1 Code Sensor", m_sensor_error_1_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 2 Code Sensor", m_sensor_error_2_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 3 Code Sensor", m_sensor_error_3_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 4 Code Sensor", m_sensor_error_4_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 5 Code Sensor", m_sensor_error_5_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 1 Time Sensor", m_sensor_error_1_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 2 Time Sensor", m_sensor_error_2_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 3 Time Sensor", m_sensor_error_3_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 4 Time Sensor", m_sensor_error_4_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Error 5 Time Sensor", m_sensor_error_5_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 1 Code Sensor", m_sensor_deactivation_1_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 2 Code Sensor", m_sensor_deactivation_2_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 3 Code Sensor", m_sensor_deactivation_3_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 4 Code Sensor", m_sensor_deactivation_4_code.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 5 Code Sensor", m_sensor_deactivation_5_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 1 Time Sensor", m_sensor_deactivation_1_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 2 Time Sensor", m_sensor_deactivation_2_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 3 Time Sensor", m_sensor_deactivation_3_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 4 Time Sensor", m_sensor_deactivation_4_time.get_sensor());
-        LOG_TEXT_SENSOR("", "Deactivation 5 Time Sensor", m_sensor_deactivation_5_code.get_sensor());
-#endif
+        LOG_BOOL_SENSOR("Defrost/Brine/Flow Sensor", m_sensor_defrost_brine_flow);
+        LOG_BOOL_SENSOR("Power Provider Lock Period Sensor", m_sensor_power_provider_lock_period);
+        LOG_BOOL_SENSOR("Low Pressure State Sensor", m_sensor_low_pressure_state);
+        LOG_BOOL_SENSOR("High Pressure State Sensor", m_sensor_high_pressure_state);
+        LOG_BOOL_SENSOR("Engine Protection Sensor", m_sensor_engine_protection);
+        LOG_BOOL_SENSOR("External Power Sensor", m_sensor_external_power);
+        LOG_BOOL_SENSOR("Defrost Valve Sensor", m_sensor_defrost_valve);
+        LOG_BOOL_SENSOR("Hot Water Pump Sensor", m_sensor_hot_water_pump);
+        LOG_BOOL_SENSOR("Heating Pump Sensor", m_sensor_heating_pump);
+        LOG_BOOL_SENSOR("Floor Heating Pump Sensor", m_sensor_floor_heating_pump);
+        LOG_BOOL_SENSOR("Ventilation/Pump Sensor", m_sensor_ventilation_pump);
+        LOG_BOOL_SENSOR("Housing Ventilation Sensor", m_sensor_housing_ventilation);
+        LOG_BOOL_SENSOR("Compressor 1 Sensor", m_sensor_compressor_1);
+        LOG_BOOL_SENSOR("Compressor 2 Sensor", m_sensor_compressor_2);
+        LOG_BOOL_SENSOR("Extra Pump Sensor", m_sensor_extra_pump);
+        LOG_BOOL_SENSOR("Secondary Heater 1 Sensor", m_sensor_secondary_heater_1);
+        LOG_BOOL_SENSOR("Secondary Heater 2 Failure Sensor", m_sensor_secondary_heater_2_failure);
+        LOG_BOOL_SENSOR("Device Communication Sensor", m_sensor_device_communication);
+
+        LOG_STRING_SENSOR("Device Type Sensor", m_sensor_device_type);
+        LOG_STRING_SENSOR("Firmware Version Sensor", m_sensor_firmware_version);
+        LOG_STRING_SENSOR("Bivalence Level Sensor", m_sensor_bivalence_level);
+        LOG_STRING_SENSOR("Operational State Sensor", m_sensor_operational_state);
+        LOG_STRING_SENSOR("Mixer 1 Sensor", m_sensor_mixer_1_state);
+
+        LOG_DURATION_SENSOR("Operating Hours Compressor 1 Sensor", m_sensor_operating_hours_compressor_1);
+        LOG_DURATION_SENSOR("Average Operating Time Compressor 1 Sensor", m_sensor_average_operating_time_compressor_1);
+        LOG_DURATION_SENSOR("Operating Hours Compressor 2 Sensor", m_sensor_operating_hours_compressor_2);
+        LOG_DURATION_SENSOR("Average Operating Time Compressor 2 Sensor", m_sensor_average_operating_time_compressor_2);
+        LOG_DURATION_SENSOR("Operating Hours Secondary Heater 1 Sensor", m_sensor_operating_hours_secondary_heater_1);
+        LOG_DURATION_SENSOR("Operating Hours Secondary Heater 2 Sensor", m_sensor_operating_hours_secondary_heater_2);
+        LOG_DURATION_SENSOR("Operating Hours Heat Pump Sensor", m_sensor_operating_hours_heat_pump);
+
+        LOG_STRING_SENSOR("Error 1 Code Sensor", m_sensor_error_1_code);
+        LOG_STRING_SENSOR("Error 2 Code Sensor", m_sensor_error_2_code);
+        LOG_STRING_SENSOR("Error 3 Code Sensor", m_sensor_error_3_code);
+        LOG_STRING_SENSOR("Error 4 Code Sensor", m_sensor_error_4_code);
+        LOG_STRING_SENSOR("Error 5 Code Sensor", m_sensor_error_5_code);
+        LOG_STRING_SENSOR("Error 1 Time Sensor", m_sensor_error_1_time);
+        LOG_STRING_SENSOR("Error 2 Time Sensor", m_sensor_error_2_time);
+        LOG_STRING_SENSOR("Error 3 Time Sensor", m_sensor_error_3_time);
+        LOG_STRING_SENSOR("Error 4 Time Sensor", m_sensor_error_4_time);
+        LOG_STRING_SENSOR("Error 5 Time Sensor", m_sensor_error_5_time);
+        LOG_STRING_SENSOR("Deactivation 1 Code Sensor", m_sensor_deactivation_1_code);
+        LOG_STRING_SENSOR("Deactivation 2 Code Sensor", m_sensor_deactivation_2_code);
+        LOG_STRING_SENSOR("Deactivation 3 Code Sensor", m_sensor_deactivation_3_code);
+        LOG_STRING_SENSOR("Deactivation 4 Code Sensor", m_sensor_deactivation_4_code);
+        LOG_STRING_SENSOR("Deactivation 5 Code Sensor", m_sensor_deactivation_5_time);
+        LOG_STRING_SENSOR("Deactivation 1 Time Sensor", m_sensor_deactivation_1_time);
+        LOG_STRING_SENSOR("Deactivation 2 Time Sensor", m_sensor_deactivation_2_time);
+        LOG_STRING_SENSOR("Deactivation 3 Time Sensor", m_sensor_deactivation_3_time);
+        LOG_STRING_SENSOR("Deactivation 4 Time Sensor", m_sensor_deactivation_4_time);
+        LOG_STRING_SENSOR("Deactivation 5 Time Sensor", m_sensor_deactivation_5_code);
     }
 
     void Luxtronik::add_dataset(const char* code)
@@ -595,6 +611,52 @@ namespace esphome::luxtronik_v1
             start = end + 1;
             end = response.find(DELIMITER, start);
             m_sensor_secondary_heater_2_failure.set_state(response, start, end);
+
+            next_dataset();
+        }
+        else if (starts_with(response, TYPE_OPERATING_HOURS))
+        {
+            m_timer.cancel();
+
+            size_t start = INDEX_RESPONSE_START;
+            size_t end = response.find(DELIMITER, start);
+            // skip number of elements
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_operating_hours_compressor_1.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_impulses_compressor_1.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_average_operating_time_compressor_1.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_operating_hours_compressor_2.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_impulses_compressor_2.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_average_operating_time_compressor_2.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_operating_hours_secondary_heater_1.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_operating_hours_secondary_heater_2.set_state(response, start, end);
+
+            start = end + 1;
+            end = response.find(DELIMITER, start);
+            m_sensor_operating_hours_heat_pump.set_state(response, start, end);
 
             next_dataset();
         }

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -66,67 +66,77 @@ namespace esphome::luxtronik_v1
         void add_dataset(const char* code);
 
 #ifdef USE_SENSOR
-        void set_sensor_flow_temperature(sensor::Sensor* sensor)                        { m_sensor_flow_temperature.set_sensor(sensor);                }
-        void set_sensor_return_temperature(sensor::Sensor* sensor)                      { m_sensor_return_temperature.set_sensor(sensor);              }
-        void set_sensor_return_set_temperature(sensor::Sensor* sensor)                  { m_sensor_return_set_temperature.set_sensor(sensor);          }
-        void set_sensor_hot_gas_temperature(sensor::Sensor* sensor)                     { m_sensor_hot_gas_temperature.set_sensor(sensor);             }
-        void set_sensor_outside_temperature(sensor::Sensor* sensor)                     { m_sensor_outside_temperature.set_sensor(sensor);             }
-        void set_sensor_hot_water_temperature(sensor::Sensor* sensor)                   { m_sensor_hot_water_temperature.set_sensor(sensor);           }
-        void set_sensor_hot_water_set_temperature(sensor::Sensor* sensor)               { m_sensor_hot_water_set_temperature.set_sensor(sensor);       }
-        void set_sensor_heat_source_input_temperature(sensor::Sensor* sensor)           { m_sensor_heat_source_input_temperature.set_sensor(sensor);   }
-        void set_sensor_heat_source_output_temperature(sensor::Sensor* sensor)          { m_sensor_heat_source_output_temperature.set_sensor(sensor);  }
-        void set_sensor_mixed_circuit_1_temperature(sensor::Sensor* sensor)             { m_sensor_mixed_circuit_1_temperature.set_sensor(sensor);     }
-        void set_sensor_mixed_circuit_1_set_temperature(sensor::Sensor* sensor)         { m_sensor_mixed_circuit_1_set_temperature.set_sensor(sensor); }
-        void set_sensor_remote_adjuster_temperature(sensor::Sensor* sensor)             { m_sensor_remote_adjuster_temperature.set_sensor(sensor);     }
+        void set_sensor_flow_temperature(sensor::Sensor* sensor)                { m_sensor_flow_temperature.set_sensor(sensor);                }
+        void set_sensor_return_temperature(sensor::Sensor* sensor)              { m_sensor_return_temperature.set_sensor(sensor);              }
+        void set_sensor_return_set_temperature(sensor::Sensor* sensor)          { m_sensor_return_set_temperature.set_sensor(sensor);          }
+        void set_sensor_hot_gas_temperature(sensor::Sensor* sensor)             { m_sensor_hot_gas_temperature.set_sensor(sensor);             }
+        void set_sensor_outside_temperature(sensor::Sensor* sensor)             { m_sensor_outside_temperature.set_sensor(sensor);             }
+        void set_sensor_hot_water_temperature(sensor::Sensor* sensor)           { m_sensor_hot_water_temperature.set_sensor(sensor);           }
+        void set_sensor_hot_water_set_temperature(sensor::Sensor* sensor)       { m_sensor_hot_water_set_temperature.set_sensor(sensor);       }
+        void set_sensor_heat_source_input_temperature(sensor::Sensor* sensor)   { m_sensor_heat_source_input_temperature.set_sensor(sensor);   }
+        void set_sensor_heat_source_output_temperature(sensor::Sensor* sensor)  { m_sensor_heat_source_output_temperature.set_sensor(sensor);  }
+        void set_sensor_mixed_circuit_1_temperature(sensor::Sensor* sensor)     { m_sensor_mixed_circuit_1_temperature.set_sensor(sensor);     }
+        void set_sensor_mixed_circuit_1_set_temperature(sensor::Sensor* sensor) { m_sensor_mixed_circuit_1_set_temperature.set_sensor(sensor); }
+        void set_sensor_remote_adjuster_temperature(sensor::Sensor* sensor)     { m_sensor_remote_adjuster_temperature.set_sensor(sensor);     }
+        void set_sensor_impulses_compressor_1(sensor::Sensor* sensor)           { m_sensor_impulses_compressor_1.set_sensor(sensor);           }
+        void set_sensor_impulses_compressor_2(sensor::Sensor* sensor)           { m_sensor_impulses_compressor_2.set_sensor(sensor);           }
 #endif
 #ifdef USE_BINARY_SENSOR
-        void set_sensor_defrost_brine_flow(binary_sensor::BinarySensor* sensor)         { m_sensor_defrost_brine_flow.set_sensor(sensor);              }
-        void set_sensor_power_provider_lock_period(binary_sensor::BinarySensor* sensor) { m_sensor_power_provider_lock_period.set_sensor(sensor);      }
-        void set_sensor_high_pressure_state(binary_sensor::BinarySensor* sensor)        { m_sensor_high_pressure_state.set_sensor(sensor);             }
-        void set_sensor_engine_protection(binary_sensor::BinarySensor* sensor)          { m_sensor_engine_protection.set_sensor(sensor);               }
-        void set_sensor_low_pressure_state(binary_sensor::BinarySensor* sensor)         { m_sensor_low_pressure_state.set_sensor(sensor);              }
-        void set_sensor_external_power(binary_sensor::BinarySensor* sensor)             { m_sensor_external_power.set_sensor(sensor);                  }
-        void set_sensor_defrost_valve(binary_sensor::BinarySensor* sensor)              { m_sensor_defrost_valve.set_sensor(sensor);                   }
-        void set_sensor_hot_water_pump(binary_sensor::BinarySensor* sensor)             { m_sensor_hot_water_pump.set_sensor(sensor);                  }
-        void set_sensor_floor_heating_pump(binary_sensor::BinarySensor* sensor)         { m_sensor_floor_heating_pump.set_sensor(sensor);              }
-        void set_sensor_heating_pump(binary_sensor::BinarySensor* sensor)               { m_sensor_heating_pump.set_sensor(sensor);                    }
-        void set_sensor_housing_ventilation(binary_sensor::BinarySensor* sensor)        { m_sensor_housing_ventilation.set_sensor(sensor);             }
-        void set_sensor_ventilation_pump(binary_sensor::BinarySensor* sensor)           { m_sensor_ventilation_pump.set_sensor(sensor);                }
-        void set_sensor_compressor_1(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_1.set_sensor(sensor);                    }
-        void set_sensor_compressor_2(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_2.set_sensor(sensor);                    }
-        void set_sensor_extra_pump(binary_sensor::BinarySensor* sensor)                 { m_sensor_extra_pump.set_sensor(sensor);                      }
-        void set_sensor_secondary_heater_1(binary_sensor::BinarySensor* sensor)         { m_sensor_secondary_heater_1.set_sensor(sensor);              }
-        void set_sensor_secondary_heater_2_failure(binary_sensor::BinarySensor* sensor) { m_sensor_secondary_heater_2_failure.set_sensor(sensor);      }
-        void set_sensor_device_communication(binary_sensor::BinarySensor* sensor)       { m_sensor_device_communication.set_sensor(sensor);            }
+        void set_sensor_defrost_brine_flow(binary_sensor::BinarySensor* sensor)         { m_sensor_defrost_brine_flow.set_sensor(sensor);         }
+        void set_sensor_power_provider_lock_period(binary_sensor::BinarySensor* sensor) { m_sensor_power_provider_lock_period.set_sensor(sensor); }
+        void set_sensor_high_pressure_state(binary_sensor::BinarySensor* sensor)        { m_sensor_high_pressure_state.set_sensor(sensor);        }
+        void set_sensor_engine_protection(binary_sensor::BinarySensor* sensor)          { m_sensor_engine_protection.set_sensor(sensor);          }
+        void set_sensor_low_pressure_state(binary_sensor::BinarySensor* sensor)         { m_sensor_low_pressure_state.set_sensor(sensor);         }
+        void set_sensor_external_power(binary_sensor::BinarySensor* sensor)             { m_sensor_external_power.set_sensor(sensor);             }
+        void set_sensor_defrost_valve(binary_sensor::BinarySensor* sensor)              { m_sensor_defrost_valve.set_sensor(sensor);              }
+        void set_sensor_hot_water_pump(binary_sensor::BinarySensor* sensor)             { m_sensor_hot_water_pump.set_sensor(sensor);             }
+        void set_sensor_floor_heating_pump(binary_sensor::BinarySensor* sensor)         { m_sensor_floor_heating_pump.set_sensor(sensor);         }
+        void set_sensor_heating_pump(binary_sensor::BinarySensor* sensor)               { m_sensor_heating_pump.set_sensor(sensor);               }
+        void set_sensor_housing_ventilation(binary_sensor::BinarySensor* sensor)        { m_sensor_housing_ventilation.set_sensor(sensor);        }
+        void set_sensor_ventilation_pump(binary_sensor::BinarySensor* sensor)           { m_sensor_ventilation_pump.set_sensor(sensor);           }
+        void set_sensor_compressor_1(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_1.set_sensor(sensor);               }
+        void set_sensor_compressor_2(binary_sensor::BinarySensor* sensor)               { m_sensor_compressor_2.set_sensor(sensor);               }
+        void set_sensor_extra_pump(binary_sensor::BinarySensor* sensor)                 { m_sensor_extra_pump.set_sensor(sensor);                 }
+        void set_sensor_secondary_heater_1(binary_sensor::BinarySensor* sensor)         { m_sensor_secondary_heater_1.set_sensor(sensor);         }
+        void set_sensor_secondary_heater_2_failure(binary_sensor::BinarySensor* sensor) { m_sensor_secondary_heater_2_failure.set_sensor(sensor); }
+        void set_sensor_device_communication(binary_sensor::BinarySensor* sensor)       { m_sensor_device_communication.set_sensor(sensor);       }
 #endif
 #ifdef USE_TEXT_SENSOR
-        void set_sensor_mixer_1_state(text_sensor::TextSensor* sensor)                  { m_sensor_mixer_1_state.set_sensor(sensor);                   }
-        void set_sensor_device_type(text_sensor::TextSensor* sensor)                    { m_sensor_device_type.set_sensor(sensor);                     }
-        void set_sensor_firmware_version(text_sensor::TextSensor* sensor)               { m_sensor_firmware_version.set_sensor(sensor);                }
-        void set_sensor_bivalence_level(text_sensor::TextSensor* sensor)                { m_sensor_bivalence_level.set_sensor(sensor);                 }
-        void set_sensor_operational_state(text_sensor::TextSensor* sensor)              { m_sensor_operational_state.set_sensor(sensor);               }
-        void set_sensor_heating_mode(text_sensor::TextSensor* sensor)                   { m_sensor_heating_mode.set_sensor(sensor);                    }
-        void set_sensor_hot_water_mode(text_sensor::TextSensor* sensor)                 { m_sensor_hot_water_mode.set_sensor(sensor);                  }
-        void set_sensor_error_1_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_1_code.set_sensor(sensor);                    }
-        void set_sensor_error_2_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_2_code.set_sensor(sensor);                    }
-        void set_sensor_error_3_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_3_code.set_sensor(sensor);                    }
-        void set_sensor_error_4_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_4_code.set_sensor(sensor);                    }
-        void set_sensor_error_5_code(text_sensor::TextSensor* sensor)                   { m_sensor_error_5_code.set_sensor(sensor);                    }
-        void set_sensor_error_1_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_1_time.set_sensor(sensor);                    }
-        void set_sensor_error_2_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_2_time.set_sensor(sensor);                    }
-        void set_sensor_error_3_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_3_time.set_sensor(sensor);                    }
-        void set_sensor_error_4_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_4_time.set_sensor(sensor);                    }
-        void set_sensor_error_5_time(text_sensor::TextSensor* sensor)                   { m_sensor_error_5_time.set_sensor(sensor);                    }
-        void set_sensor_deactivation_1_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_1_code.set_sensor(sensor);             }
-        void set_sensor_deactivation_2_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_2_code.set_sensor(sensor);             }
-        void set_sensor_deactivation_3_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_code.set_sensor(sensor);             }
-        void set_sensor_deactivation_4_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_code.set_sensor(sensor);             }
-        void set_sensor_deactivation_5_code(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_code.set_sensor(sensor);             }
-        void set_sensor_deactivation_1_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_1_time.set_sensor(sensor);             }
-        void set_sensor_deactivation_2_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_2_time.set_sensor(sensor);             }
-        void set_sensor_deactivation_3_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_3_time.set_sensor(sensor);             }
-        void set_sensor_deactivation_4_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_4_time.set_sensor(sensor);             }
-        void set_sensor_deactivation_5_time(text_sensor::TextSensor* sensor)            { m_sensor_deactivation_5_time.set_sensor(sensor);             }
+        void set_sensor_mixer_1_state(text_sensor::TextSensor* sensor)                       { m_sensor_mixer_1_state.set_sensor(sensor);                       }
+        void set_sensor_device_type(text_sensor::TextSensor* sensor)                         { m_sensor_device_type.set_sensor(sensor);                         }
+        void set_sensor_firmware_version(text_sensor::TextSensor* sensor)                    { m_sensor_firmware_version.set_sensor(sensor);                    }
+        void set_sensor_bivalence_level(text_sensor::TextSensor* sensor)                     { m_sensor_bivalence_level.set_sensor(sensor);                     }
+        void set_sensor_operational_state(text_sensor::TextSensor* sensor)                   { m_sensor_operational_state.set_sensor(sensor);                   }
+        void set_sensor_heating_mode(text_sensor::TextSensor* sensor)                        { m_sensor_heating_mode.set_sensor(sensor);                        }
+        void set_sensor_hot_water_mode(text_sensor::TextSensor* sensor)                      { m_sensor_hot_water_mode.set_sensor(sensor);                      }
+        void set_sensor_error_1_code(text_sensor::TextSensor* sensor)                        { m_sensor_error_1_code.set_sensor(sensor);                        }
+        void set_sensor_error_2_code(text_sensor::TextSensor* sensor)                        { m_sensor_error_2_code.set_sensor(sensor);                        }
+        void set_sensor_error_3_code(text_sensor::TextSensor* sensor)                        { m_sensor_error_3_code.set_sensor(sensor);                        }
+        void set_sensor_error_4_code(text_sensor::TextSensor* sensor)                        { m_sensor_error_4_code.set_sensor(sensor);                        }
+        void set_sensor_error_5_code(text_sensor::TextSensor* sensor)                        { m_sensor_error_5_code.set_sensor(sensor);                        }
+        void set_sensor_error_1_time(text_sensor::TextSensor* sensor)                        { m_sensor_error_1_time.set_sensor(sensor);                        }
+        void set_sensor_error_2_time(text_sensor::TextSensor* sensor)                        { m_sensor_error_2_time.set_sensor(sensor);                        }
+        void set_sensor_error_3_time(text_sensor::TextSensor* sensor)                        { m_sensor_error_3_time.set_sensor(sensor);                        }
+        void set_sensor_error_4_time(text_sensor::TextSensor* sensor)                        { m_sensor_error_4_time.set_sensor(sensor);                        }
+        void set_sensor_error_5_time(text_sensor::TextSensor* sensor)                        { m_sensor_error_5_time.set_sensor(sensor);                        }
+        void set_sensor_deactivation_1_code(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_1_code.set_sensor(sensor);                 }
+        void set_sensor_deactivation_2_code(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_2_code.set_sensor(sensor);                 }
+        void set_sensor_deactivation_3_code(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_3_code.set_sensor(sensor);                 }
+        void set_sensor_deactivation_4_code(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_4_code.set_sensor(sensor);                 }
+        void set_sensor_deactivation_5_code(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_5_code.set_sensor(sensor);                 }
+        void set_sensor_deactivation_1_time(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_1_time.set_sensor(sensor);                 }
+        void set_sensor_deactivation_2_time(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_2_time.set_sensor(sensor);                 }
+        void set_sensor_deactivation_3_time(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_3_time.set_sensor(sensor);                 }
+        void set_sensor_deactivation_4_time(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_4_time.set_sensor(sensor);                 }
+        void set_sensor_deactivation_5_time(text_sensor::TextSensor* sensor)                 { m_sensor_deactivation_5_time.set_sensor(sensor);                 }
+
+        void set_sensor_operating_hours_compressor_1(text_sensor::TextSensor* sensor, int32_t format)        { m_sensor_operating_hours_compressor_1.set_sensor(sensor, format);        }
+        void set_sensor_average_operating_time_compressor_1(text_sensor::TextSensor* sensor, int32_t format) { m_sensor_average_operating_time_compressor_1.set_sensor(sensor, format); }
+        void set_sensor_operating_hours_compressor_2(text_sensor::TextSensor* sensor, int32_t format)        { m_sensor_operating_hours_compressor_2.set_sensor(sensor, format);        }
+        void set_sensor_average_operating_time_compressor_2(text_sensor::TextSensor* sensor, int32_t format) { m_sensor_average_operating_time_compressor_2.set_sensor(sensor, format); }
+        void set_sensor_operating_hours_secondary_heater_1(text_sensor::TextSensor* sensor, int32_t format)  { m_sensor_operating_hours_secondary_heater_1.set_sensor(sensor, format);  }
+        void set_sensor_operating_hours_secondary_heater_2(text_sensor::TextSensor* sensor, int32_t format)  { m_sensor_operating_hours_secondary_heater_2.set_sensor(sensor, format);  }
+        void set_sensor_operating_hours_heat_pump(text_sensor::TextSensor* sensor, int32_t format)           { m_sensor_operating_hours_heat_pump.set_sensor(sensor, format);           }
 #endif
 
     private:
@@ -190,6 +200,17 @@ namespace esphome::luxtronik_v1
         // modes
         StringSensor m_sensor_heating_mode;    // 3405:2 - Betriebsart Heizung
         StringSensor m_sensor_hot_water_mode;  // 3505:2 - Betriebsart Brauchwarmwasser
+
+        // operating hours
+        DurationSensor m_sensor_operating_hours_compressor_1;         // 1450:2  - Betriebsstunden Verdichter 1
+        NumericSensor  m_sensor_impulses_compressor_1;                // 1450:3  - Impulse Verdichter 1
+        DurationSensor m_sensor_average_operating_time_compressor_1;  // 1450:4  - Durchschnittliche Laufzeit Verdichter 1
+        DurationSensor m_sensor_operating_hours_compressor_2;         // 1450:5  - Betriebsstunden Verdichter 2
+        NumericSensor  m_sensor_impulses_compressor_2;                // 1450:6  - Impulse Verdichter 2
+        DurationSensor m_sensor_average_operating_time_compressor_2;  // 1450:7  - Durchschnittliche Laufzeit Verdichter 2
+        DurationSensor m_sensor_operating_hours_secondary_heater_1;   // 1450:8  - Betriebsstunden Zweiter Wärmeerzeuger 1
+        DurationSensor m_sensor_operating_hours_secondary_heater_2;   // 1450:9  - Betriebsstunden Zweiter Wärmeerzeuger 2
+        DurationSensor m_sensor_operating_hours_heat_pump;            // 1450:10 - Betriebsstunden Wärmepumpe
 
         // errors
         StringSensor m_sensor_error_1_code;  // 1500:1500:2   - Fehler 1 - Code

--- a/components/luxtronik_v1/luxtronik_sensor.h
+++ b/components/luxtronik_v1/luxtronik_sensor.h
@@ -41,15 +41,74 @@
 #include <string>
 
 
+#ifdef USE_SENSOR
+#define LOG_NUMERIC_SENSOR(type, obj) LOG_SENSOR("", type, obj.get_sensor());
+#define LOG_TEMPERATURE_SENSOR(type, obj) LOG_SENSOR("", type, obj.get_sensor());
+#else
+#define LOG_NUMERIC_SENSOR(type, obj)
+#define LOG_TEMPERATURE_SENSOR(type, obj)
+#endif
+
+#ifdef USE_BINARY_SENSOR
+#define LOG_BOOL_SENSOR(type, obj) LOG_BINARY_SENSOR("", type, obj.get_sensor());
+#else
+#define LOG_BOOL_SENSOR(type, obj)
+#endif
+
+#ifdef USE_TEXT_SENSOR
+#define LOG_STRING_SENSOR(type, obj) LOG_TEXT_SENSOR("", type, obj.get_sensor());
+#define LOG_DURATION_SENSOR(type, obj) \
+    LOG_TEXT_SENSOR("", type, obj.get_sensor()); \
+    if (obj.has_sensor()) \
+    { \
+        ESP_LOGCONFIG(TAG, "  Format: %u", obj.get_format()); \
+    }
+#else
+#define LOG_STRING_SENSOR(type, obj)
+#define LOG_DURATION_SENSOR(type, obj)
+#endif
+
+
 namespace esphome::luxtronik_v1
 {
-    class TemperatureSensor
+    class NumericSensor
     {
     public:
-        TemperatureSensor()
+        NumericSensor()
 #ifdef USE_SENSOR
             : m_sensor(nullptr)
 #endif
+        {
+        }
+
+        void set_state(const std::string& input_str, uint16_t start, uint16_t end)
+        {
+#ifdef USE_SENSOR
+            if (m_sensor != nullptr)
+            {
+                m_sensor->publish_state(
+                            static_cast<float>(
+                                std::atoi(input_str.substr(start, end - start).c_str())));
+            }
+#endif
+        }
+
+#ifdef USE_SENSOR
+        void set_sensor(sensor::Sensor* sensor) { m_sensor = sensor; }
+        sensor::Sensor* get_sensor() { return m_sensor; }
+#endif
+
+    protected:
+#ifdef USE_SENSOR
+        sensor::Sensor* m_sensor;
+#endif
+    };
+
+    class TemperatureSensor : public NumericSensor
+    {
+    public:
+        TemperatureSensor()
+            : NumericSensor()
         {
         }
 
@@ -64,16 +123,6 @@ namespace esphome::luxtronik_v1
             }
 #endif
         }
-
-#ifdef USE_SENSOR
-        void set_sensor(sensor::Sensor* sensor) { m_sensor = sensor; }
-        sensor::Sensor* get_sensor() { return m_sensor; }
-#endif
-
-    private:
-#ifdef USE_SENSOR
-        sensor::Sensor* m_sensor;
-#endif
     };
 
     class StringSensor
@@ -126,6 +175,95 @@ namespace esphome::luxtronik_v1
 #endif
     };
 
+    class DurationSensor : public StringSensor
+    {
+    public:
+        enum class Format
+        {
+            ISO_8601,       // ISO-8601 duration format
+            HUMAN_READABLE  // Human readable string in the form "h:mm:ss"
+        };
+
+        DurationSensor()
+            : StringSensor()
+            , m_format(Format::ISO_8601)
+        {
+        }
+
+        void set_state(const std::string& input_str, uint16_t start, uint16_t end)
+        {
+#ifdef USE_TEXT_SENSOR
+            if (m_sensor != nullptr)
+            {
+                std::string state;
+                uint32_t value = static_cast<uint32_t>(std::atol(input_str.substr(start, end - start).c_str()));
+
+                if (value > 0)
+                {
+                    uint32_t hours = value / 3600;
+                    uint32_t minutes = (value / 60) % 60;
+                    uint32_t seconds = value % 60;
+
+                    switch (m_format)
+                    {
+                        case Format::ISO_8601:
+                        {
+                            state = "PT";
+
+                            if (hours > 0)   { state += std::to_string(hours)   + "H"; }
+                            if (minutes > 0) { state += std::to_string(minutes) + "M"; }
+                            if (seconds > 0) { state += std::to_string(seconds) + "S"; }
+
+                            break;
+                        }
+                        case Format::HUMAN_READABLE:
+                        {
+                            state = std::to_string(hours) + ':'
+                                    + ((minutes < 10) ? '0' + std::to_string(minutes) : std::to_string(minutes)) + ':'
+                                    + ((seconds < 10) ? '0' + std::to_string(seconds) : std::to_string(seconds));
+
+                            break;
+                        }
+                    }
+                }
+
+                m_sensor->publish_state(state);
+            }
+#endif
+        }
+
+#ifdef ESPHOME_LOG_HAS_CONFIG
+        const char* get_format() const
+        {
+            const char* format = nullptr;
+
+            switch (m_format)
+            {
+                case Format::ISO_8601:       { format = "iso_8601";       break; }
+                case Format::HUMAN_READABLE: { format = "human_readable"; break; }
+            }
+
+            return format;
+        }
+#endif
+
+#ifdef USE_TEXT_SENSOR
+        void set_sensor(text_sensor::TextSensor* sensor, int32_t format)
+        {
+            m_sensor = sensor;
+
+            switch (format)
+            {
+                case 0: { m_format = Format::ISO_8601;       break; }
+                case 1: { m_format = Format::HUMAN_READABLE; break; }
+            }
+        }
+#endif
+
+    protected:
+        Format m_format;
+    };
+
     class BoolSensor
     {
     public:
@@ -162,7 +300,7 @@ namespace esphome::luxtronik_v1
         binary_sensor::BinarySensor* get_sensor() { return m_sensor; }
 #endif
 
-    private:
+    protected:
 #ifdef USE_BINARY_SENSOR
         binary_sensor::BinarySensor* m_sensor;
 #endif

--- a/components/luxtronik_v1/sensor.py
+++ b/components/luxtronik_v1/sensor.py
@@ -28,6 +28,7 @@ from esphome.components import sensor
 from esphome.const      import (
     CONF_ID,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     DEVICE_CLASS_TEMPERATURE,
     UNIT_CELSIUS
 )
@@ -51,89 +52,101 @@ CONF_HEAT_SOURCE_OUTPUT_TEMPERATURE  = "heat_source_output_temperature"
 CONF_MIXED_CIRCUIT_1_TEMPERATURE     = "mixed_circuit_1_temperature"
 CONF_MIXED_CIRCUIT_1_SET_TEMPERATURE = "mixed_circuit_1_set_temperature"
 CONF_REMOTE_ADJUSTER_TEMPERATURE     = "remote_adjuster_temperature"
+CONF_IMPULSES_COMPRESSOR_1           = "impulses_compressor_1"
+CONF_IMPULSES_COMPRESSOR_2           = "impulses_compressor_2"
 
 CONFIG_SCHEMA = cv.Schema(
 {
     cv.GenerateID(CONF_LUXTRONIK_ID): cv.use_id(Luxtronik),
     cv.Optional(CONF_FLOW_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:thermometer-chevron-up"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:thermometer-chevron-up"
     ),
     cv.Optional(CONF_RETURN_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:thermometer-chevron-down"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:thermometer-chevron-down"
     ),
     cv.Optional(CONF_RETURN_SET_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:thermometer-chevron-down"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:thermometer-chevron-down"
     ),
     cv.Optional(CONF_HOT_GAS_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1
     ),
     cv.Optional(CONF_OUTSIDE_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:sun-thermometer"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:sun-thermometer"
     ),
     cv.Optional(CONF_HOT_WATER_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:coolant-temperature"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:coolant-temperature"
     ),
     cv.Optional(CONF_HOT_WATER_SET_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:coolant-temperature"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:coolant-temperature"
     ),
     cv.Optional(CONF_HEAT_SOURCE_INPUT_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:thermometer-chevron-up"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:thermometer-chevron-up"
     ),
     cv.Optional(CONF_HEAT_SOURCE_OUTPUT_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        icon="mdi:thermometer-chevron-down"
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1,
+        icon = "mdi:thermometer-chevron-down"
     ),
     cv.Optional(CONF_MIXED_CIRCUIT_1_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1
     ),
     cv.Optional(CONF_MIXED_CIRCUIT_1_SET_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1
     ),
     cv.Optional(CONF_REMOTE_ADJUSTER_TEMPERATURE): sensor.sensor_schema(
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1
+        device_class = DEVICE_CLASS_TEMPERATURE,
+        state_class = STATE_CLASS_MEASUREMENT,
+        unit_of_measurement = UNIT_CELSIUS,
+        accuracy_decimals = 1
+    ),
+    cv.Optional(CONF_IMPULSES_COMPRESSOR_1): sensor.sensor_schema(
+        state_class = STATE_CLASS_TOTAL_INCREASING,
+        accuracy_decimals = 0,
+        icon = "mdi:counter"
+    ),
+    cv.Optional(CONF_IMPULSES_COMPRESSOR_2): sensor.sensor_schema(
+        state_class = STATE_CLASS_TOTAL_INCREASING,
+        accuracy_decimals = 0,
+        icon = "mdi:counter"
     )
 })
 

--- a/components/luxtronik_v1/text_sensor.py
+++ b/components/luxtronik_v1/text_sensor.py
@@ -37,120 +37,157 @@ from .                  import (
 
 CODEOWNERS = ["@jensrossbach"]
 
-CONF_DEVICE_TYPE         = "device_type"
-CONF_FIRMWARE_VERSION    = "firmware_version"
-CONF_BIVALENCE_LEVEL     = "bivalence_level"
-CONF_OPERATIONAL_STATE   = "operational_state"
-CONF_HEATING_MODE        = "heating_mode"
-CONF_HOT_WATER_MODE      = "hot_water_mode"
-CONF_OUTPUT_MIXER_1      = "mixer_1_state"
-CONF_ERROR_1_CODE        = "error_1_code"
-CONF_ERROR_1_TIME        = "error_1_time"
-CONF_ERROR_2_CODE        = "error_2_code"
-CONF_ERROR_2_TIME        = "error_2_time"
-CONF_ERROR_3_CODE        = "error_3_code"
-CONF_ERROR_3_TIME        = "error_3_time"
-CONF_ERROR_4_CODE        = "error_4_code"
-CONF_ERROR_4_TIME        = "error_4_time"
-CONF_ERROR_5_CODE        = "error_5_code"
-CONF_ERROR_5_TIME        = "error_5_time"
-CONF_DEACTIVATION_1_CODE = "deactivation_1_code"
-CONF_DEACTIVATION_1_TIME = "deactivation_1_time"
-CONF_DEACTIVATION_2_CODE = "deactivation_2_code"
-CONF_DEACTIVATION_2_TIME = "deactivation_2_time"
-CONF_DEACTIVATION_3_CODE = "deactivation_3_code"
-CONF_DEACTIVATION_3_TIME = "deactivation_3_time"
-CONF_DEACTIVATION_4_CODE = "deactivation_4_code"
-CONF_DEACTIVATION_4_TIME = "deactivation_4_time"
-CONF_DEACTIVATION_5_CODE = "deactivation_5_code"
-CONF_DEACTIVATION_5_TIME = "deactivation_5_time"
+CONF_DEVICE_TYPE                         = "device_type"
+CONF_FIRMWARE_VERSION                    = "firmware_version"
+CONF_BIVALENCE_LEVEL                     = "bivalence_level"
+CONF_OPERATIONAL_STATE                   = "operational_state"
+CONF_HEATING_MODE                        = "heating_mode"
+CONF_HOT_WATER_MODE                      = "hot_water_mode"
+CONF_OUTPUT_MIXER_1                      = "mixer_1_state"
+CONF_OPERATING_HOURS_COMPRESSOR_1        = "operating_hours_compressor_1"
+CONF_AVERAGE_OPERATING_TIME_COMPRESSOR_1 = "average_operating_time_compressor_1"
+CONF_OPERATING_HOURS_COMPRESSOR_2        = "operating_hours_compressor_2"
+CONF_AVERAGE_OPERATING_TIME_COMPRESSOR_2 = "average_operating_time_compressor_2"
+CONF_OPERATING_HOURS_SECONDARY_HEATER_1  = "operating_hours_secondary_heater_1"
+CONF_OPERATING_HOURS_SECONDARY_HEATER_2  = "operating_hours_secondary_heater_2"
+CONF_OPERATING_HOURS_HEAT_PUMP           = "operating_hours_heat_pump"
+CONF_ERROR_1_CODE                        = "error_1_code"
+CONF_ERROR_1_TIME                        = "error_1_time"
+CONF_ERROR_2_CODE                        = "error_2_code"
+CONF_ERROR_2_TIME                        = "error_2_time"
+CONF_ERROR_3_CODE                        = "error_3_code"
+CONF_ERROR_3_TIME                        = "error_3_time"
+CONF_ERROR_4_CODE                        = "error_4_code"
+CONF_ERROR_4_TIME                        = "error_4_time"
+CONF_ERROR_5_CODE                        = "error_5_code"
+CONF_ERROR_5_TIME                        = "error_5_time"
+CONF_DEACTIVATION_1_CODE                 = "deactivation_1_code"
+CONF_DEACTIVATION_1_TIME                 = "deactivation_1_time"
+CONF_DEACTIVATION_2_CODE                 = "deactivation_2_code"
+CONF_DEACTIVATION_2_TIME                 = "deactivation_2_time"
+CONF_DEACTIVATION_3_CODE                 = "deactivation_3_code"
+CONF_DEACTIVATION_3_TIME                 = "deactivation_3_time"
+CONF_DEACTIVATION_4_CODE                 = "deactivation_4_code"
+CONF_DEACTIVATION_4_TIME                 = "deactivation_4_time"
+CONF_DEACTIVATION_5_CODE                 = "deactivation_5_code"
+CONF_DEACTIVATION_5_TIME                 = "deactivation_5_time"
+
+CONF_DURATION_FORMAT                     = "duration_format"
+
+DURATION_SCHEMA = cv.Schema(
+{
+    cv.Optional(CONF_DURATION_FORMAT, default = "human_readable"): cv.one_of("iso_8601", "human_readable")
+})
 
 CONFIG_SCHEMA = cv.Schema(
 {
     cv.GenerateID(CONF_LUXTRONIK_ID): cv.use_id(Luxtronik),
     cv.Optional(CONF_DEVICE_TYPE): text_sensor.text_sensor_schema(
-        icon="mdi:card-account-details"
+        icon = "mdi:card-account-details"
     ),
     cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.text_sensor_schema(
-        icon="mdi:tag"
+        icon = "mdi:tag"
     ),
     cv.Optional(CONF_BIVALENCE_LEVEL): text_sensor.text_sensor_schema(
-        icon="mdi:order-bool-descending-variant"
+        icon = "mdi:order-bool-descending-variant"
     ),
     cv.Optional(CONF_OPERATIONAL_STATE): text_sensor.text_sensor_schema(
-        icon="mdi:state-machine"
+        icon = "mdi:state-machine"
     ),
     cv.Optional(CONF_HEATING_MODE): text_sensor.text_sensor_schema(
-        icon="mdi:radiator"
+        icon = "mdi:radiator"
     ),
     cv.Optional(CONF_HOT_WATER_MODE): text_sensor.text_sensor_schema(
-        icon="mdi:water-boiler"
+        icon = "mdi:water-boiler"
     ),
     cv.Optional(CONF_OUTPUT_MIXER_1): text_sensor.text_sensor_schema(
-        icon="mdi:merge"
+        icon = "mdi:merge"
     ),
+    cv.Optional(CONF_OPERATING_HOURS_COMPRESSOR_1): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
+    cv.Optional(CONF_AVERAGE_OPERATING_TIME_COMPRESSOR_1): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
+    cv.Optional(CONF_OPERATING_HOURS_COMPRESSOR_2): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
+    cv.Optional(CONF_AVERAGE_OPERATING_TIME_COMPRESSOR_2): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
+    cv.Optional(CONF_OPERATING_HOURS_SECONDARY_HEATER_1): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
+    cv.Optional(CONF_OPERATING_HOURS_SECONDARY_HEATER_2): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
+    cv.Optional(CONF_OPERATING_HOURS_HEAT_PUMP): text_sensor.text_sensor_schema(
+        icon = "mdi:clock-start"
+    ).extend(DURATION_SCHEMA),
     cv.Optional(CONF_ERROR_1_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:alert"
+        icon = "mdi:alert"
     ),
     cv.Optional(CONF_ERROR_1_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_ERROR_2_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:alert"
+        icon = "mdi:alert"
     ),
     cv.Optional(CONF_ERROR_2_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_ERROR_3_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:alert"
+        icon = "mdi:alert"
     ),
     cv.Optional(CONF_ERROR_3_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_ERROR_4_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:alert"
+        icon = "mdi:alert"
     ),
     cv.Optional(CONF_ERROR_4_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_ERROR_5_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:alert"
+        icon = "mdi:alert"
     ),
     cv.Optional(CONF_ERROR_5_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_DEACTIVATION_1_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:information-slab-circle"
+        icon = "mdi:information-slab-circle"
     ),
     cv.Optional(CONF_DEACTIVATION_1_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_DEACTIVATION_2_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:information-slab-circle"
+        icon = "mdi:information-slab-circle"
     ),
     cv.Optional(CONF_DEACTIVATION_2_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_DEACTIVATION_3_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:information-slab-circle"
+        icon = "mdi:information-slab-circle"
     ),
     cv.Optional(CONF_DEACTIVATION_3_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_DEACTIVATION_4_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:information-slab-circle"
+        icon = "mdi:information-slab-circle"
     ),
     cv.Optional(CONF_DEACTIVATION_4_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     ),
     cv.Optional(CONF_DEACTIVATION_5_CODE): text_sensor.text_sensor_schema(
-        icon="mdi:information-slab-circle"
+        icon = "mdi:information-slab-circle"
     ),
     cv.Optional(CONF_DEACTIVATION_5_TIME): text_sensor.text_sensor_schema(
-        device_class=DEVICE_CLASS_TIMESTAMP
+        device_class = DEVICE_CLASS_TIMESTAMP
     )
 })
 
+
+DURATION_FORMAT_MAP = {"iso_8601": 0, "human_readable": 1}
 
 async def to_code(config):
     cmp = await cg.get_variable(config[CONF_LUXTRONIK_ID])
@@ -160,4 +197,7 @@ async def to_code(config):
             id = conf[CONF_ID]
             if id and id.type == text_sensor.TextSensor:
                 sens = await text_sensor.new_text_sensor(conf)
-                cg.add(getattr(cmp, f"set_sensor_{key}")(sens))
+                if CONF_DURATION_FORMAT in conf:
+                    cg.add(getattr(cmp, f"set_sensor_{key}")(sens, DURATION_FORMAT_MAP[conf[CONF_DURATION_FORMAT]]))
+                else:
+                    cg.add(getattr(cmp, f"set_sensor_{key}")(sens))

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -92,6 +92,10 @@ sensor:
       name: Soll-Temperatur Vorlauf Mischkreis 1
     remote_adjuster_temperature:
       name: Temperatur Raumfernversteller
+    impulses_compressor_1:
+      name: Impulse Verdichter 1
+    impulses_compressor_2:
+      name: Impulse Verdichter 2
   - platform: wifi_signal
     name: Wi-Fi Signal
     update_interval: 60s
@@ -210,6 +214,20 @@ text_sensor:
           - idle -> Keine Ansteuerung
           - opening -> Fährt auf
           - closing -> Fährt zu
+    operating_hours_compressor_1:
+      name: Betriebsstunden Verdichter 1
+    average_operating_time_compressor_1:
+      name: Durchschnittliche Laufzeit Verdichter 1
+    operating_hours_compressor_2:
+      name: Betriebsstunden Verdichter 2
+    average_operating_time_compressor_2:
+      name: Durchschnittliche Laufzeit Verdichter 2
+    operating_hours_secondary_heater_1:
+      name: Betriebsstunden Zweiter Wärmeerzeuger 1
+    operating_hours_secondary_heater_2:
+      name: Betriebsstunden Zweiter Wärmeerzeuger 2
+    operating_hours_heat_pump:
+      name: Betriebsstunden Wärmepumpe
     error_1_code:
       name: Fehler 1 - Code
     error_1_time:


### PR DESCRIPTION
This pull request adds support for data set 1450, which includes the operating times and number of impulses of the compressors, secondary heaters and the heat pump itself. With this change, 9 additional sensors are available in the Luxtronik component.

Resolves #12