### PR TITLE
Possibility to change the hot water set temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Dieses Projekt wurde stark von der [Luxtronik V1 ESPHome-Komponente](https://git
     - [Numerische Sensoren](#numerische-sensoren)
     - [Binäre Sensoren](#binäre-sensoren)
     - [Textsensoren](#textsensoren)
+  - [Aktionen](#aktionen)
 - [Luxtronik-Konfiguration](#luxtronik-konfiguration)
 - [Hilfe/Unterstützung](SUPPORT.md)
 - [Mitwirkung](CONTRIBUTING.md)
@@ -433,6 +434,21 @@ text_sensor:
       name: Letzte Abschaltung - Zeit
 ```
 
+### Aktionen
+Die Luxtronik-Komponente stellt Aktionen zur Verfügung, um die Luxtronik Heizungssteuerung zu programmieren.
+
+#### Soll-Temperatur für Brauchwarmwasser setzen
+| Aktion | Beschreibung |
+| ------ | ------------ |
+| `luxtronik_v1.set_hot_water_set_temperature` | Setzt die Soll-Temperatur für Brauchwarmwasser auf den angegebenen Wert |
+
+##### Parameter
+| Parameter | Typ | Bereich | Beschreibung |
+| --------- | --- | ------- | ------------ |
+| `value` | `float` | 0.0&nbsp;...&nbsp;99.0 | Zielwert für die Soll-Temperatur des Brauchwarmwassers in °C |
+
+Anstelle eines festen Zahlenwerts kann auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Wert zurückgibt.
+
 ## Luxtronik-Konfiguration
 Um die serielle Schnittstelle des Luxtronik V1 Heizungssteuergeräts nutzen zu können, muss diese zunächst freigeschaltet werden. Dazu musst du im Menü der Luxtronik Benutzerschnittstelle zu _Service_ -> _Einstellungen_ -> _Datenzugang_ navigieren und die PIN `9445` eingeben. Daraufhin navigiere zu _Service_ -> _Diagnoseprogramme_ und aktiviere die Option "Standard".
 
@@ -456,6 +472,7 @@ This project was heavily inspired by the [Luxtronik V1 ESPHome component](https:
     - [Numeric Sensors](#numeric-sensors)
     - [Binary Sensors](#binary-sensors)
     - [Text Sensors](#text-sensors)
+  - [Actions](#actions)
 - [Luxtronik Configuration](#luxtronik-configuration)
 - [Help/Support](SUPPORT.md#-getting-support-for-esphome-luxtronik-v1)
 - [Contributing](CONTRIBUTING.md#contributing-to-esphome-luxtronik-v1)
@@ -865,6 +882,21 @@ text_sensor:
     deactivation_5_time:
       name: Letzte Abschaltung - Zeit
 ```
+
+### Actions
+The Luxtronik component provides actions for programming the Luxtronik heating control unit.
+
+#### Set Energy Meter
+| Action | Description |
+| ------ | ----------- |
+| `luxtronik_v1.set_hot_water_set_temperature` | Sets the hot water set temperature to the given value |
+
+##### Parameters
+| Parameter | Type | Range | Description |
+| --------- | ---- | ----- | ----------- |
+| `value` | `float` | 0.0&nbsp;...&nbsp;99.0 | Target value for the hot water set temperature in °C |
+
+Instead of a fixed numeric value, it is also possible to specify a lambda expression that returns the value to be passed to the action.
 
 ## Luxtronik Configuration
 In order to use the serial interface of the Luxtronik V1 heating control unit, it needs to be unlocked first. To do this, navigate to _Service_ -> _Einstellungen_ -> _Datenzugang_ and enter the PIN `9445`. After that, navigate to _Service_ -> _Diagnoseprogramme_ and activate the option "Standard".

--- a/components/luxtronik_v1/automation.h
+++ b/components/luxtronik_v1/automation.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+
+#include "luxtronik.h"
+
+
+namespace esphome::luxtronik_v1
+{
+    template<typename... Ts> class SetHotWaterSetTemperatureAction : public Action<Ts...>
+    {
+    public:
+    SetHotWaterSetTemperatureAction(Luxtronik *luxtronik)
+            : m_luxtronik(luxtronik)
+        {
+        }
+
+        void play(Ts... x) override
+        {
+            m_luxtronik->set_hot_water_set_temperature(m_set_temperature_value.value(x...));
+        }
+
+        template<typename V> void set_hot_water_set_temperature_value(V value)
+        {
+            m_set_temperature_value = value;
+        }
+
+    protected:
+        Luxtronik *m_luxtronik;
+        TemplatableValue<float, Ts...> m_set_temperature_value;
+    };
+}  // namespace esphome::ferraris

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -65,6 +65,7 @@ namespace esphome::luxtronik_v1
         void dump_config() override;
 
         void add_dataset(const char* code);
+        void set_hot_water_set_temperature(float value);
 
 #ifdef USE_SENSOR
         void set_sensor_flow_temperature(sensor::Sensor* sensor)                 { m_sensor_flow_temperature.set_sensor(sensor);                 }
@@ -157,6 +158,12 @@ namespace esphome::luxtronik_v1
         void handle_timeout();
         void clear_uart_buffer();
         void parse_slot(const std::string& slot, StringSensor& sensor_code, StringSensor& sensor_time);
+
+        void ack_response()
+        {
+            m_timer.cancel();
+            m_retry_count = 0;
+        }
 
         static int32_t get_number(const std::string& input_str, uint16_t start, uint16_t end)       { return std::atoi(input_str.substr(start, end - start).c_str()); }
         static bool    get_binary_state(const std::string& input_str, uint16_t start, uint16_t end) { return input_str.substr(start, end - start) != "0";             }
@@ -272,6 +279,7 @@ namespace esphome::luxtronik_v1
         bool m_response_ready;
         bool m_slot_block;
         uint16_t m_retry_count;
+        std::string m_store_config_ack;
         std::vector<const char*> m_dataset_list;
         SimpleQueue<std::string> m_request_queue;
         SimpleTimer m_timer;

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "luxtronik_sensor.h"
+#include "simple_queue.h"
 #include "simple_timer.h"
 
 #include "esphome/core/defines.h"
@@ -151,7 +152,7 @@ namespace esphome::luxtronik_v1
     private:
         void next_dataset();
         void request_data();
-        void send_request(const char* req);
+        void send_request(const std::string& request);
         void parse_response(const std::string& response);
         void handle_timeout();
         void clear_uart_buffer();
@@ -272,7 +273,7 @@ namespace esphome::luxtronik_v1
         bool m_slot_block;
         uint16_t m_retry_count;
         std::vector<const char*> m_dataset_list;
-        std::vector<const char*>::iterator m_current_dataset;
+        SimpleQueue<std::string> m_request_queue;
         SimpleTimer m_timer;
     };
 }  // namespace esphome::luxtronik_v1

--- a/components/luxtronik_v1/simple_queue.h
+++ b/components/luxtronik_v1/simple_queue.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+
+namespace esphome::luxtronik_v1
+{
+    template<class T>
+    class SimpleQueue
+    {
+    public:
+        SimpleQueue()
+            : m_head(nullptr)
+            , m_tail(nullptr)
+            , m_size(0)
+        {
+        }
+
+        ~SimpleQueue()
+        {
+            clear();
+        }
+
+        SimpleQueue(const SimpleQueue&) = delete;
+        SimpleQueue(SimpleQueue&&) = delete;
+
+        SimpleQueue& operator=(const SimpleQueue& other) = delete;
+        SimpleQueue& operator=(SimpleQueue&& other) = delete;
+
+        const T& front() const
+        {
+            return m_head->m_data;
+        }
+
+        T& front()
+        {
+            return m_head->m_data;
+        }
+
+        const T& back() const
+        {
+            return m_tail->m_data;
+        }
+
+        T& back()
+        {
+            return m_tail->m_data;
+        }
+
+        size_t size() const
+        {
+            return m_size;
+        }
+
+        bool empty() const
+        {
+            return m_size == 0;
+        }
+
+        void push_back(T&& data)
+        {
+            if (m_tail == nullptr)
+            {
+                m_tail = new ListNode(std::move(data));
+                m_head = m_tail;
+            }
+            else
+            {
+                m_tail->m_next = new ListNode(std::move(data));
+                m_tail = m_tail->m_next;
+            }
+
+            ++m_size;
+        }
+
+        void push_front(T&& data)
+        {
+            if (m_head == nullptr)
+            {
+                m_head = new ListNode(std::move(data));
+                m_tail = m_head;
+            }
+            else
+            {
+                ListNode* next = m_head;
+                m_head = new ListNode(std::move(data));
+                m_head->m_next = next;
+            }
+
+            ++m_size;
+        }
+
+        const void pop_front()
+        {
+            if (m_head != nullptr)
+            {
+                ListNode* next = m_head->m_next;
+                delete m_head;
+                m_head = next;
+
+                if (m_head == nullptr)  // last element removed
+                {
+                    m_tail = nullptr;
+                }
+
+                --m_size;
+            }
+        }
+
+        void clear()
+        {
+            while (m_head != nullptr)
+            {
+                ListNode* next = m_head->m_next;
+                delete m_head;
+                m_head = next;
+            }
+
+            m_tail = nullptr;
+            m_size = 0;
+        }
+
+    private:
+        struct ListNode
+        {
+            ListNode(T&& data)
+                : m_data(std::move(data))
+                , m_next(nullptr)
+            {
+            }
+
+            T m_data;
+            ListNode* m_next;
+        };
+
+        ListNode* m_head;
+        ListNode* m_tail;
+        size_t m_size;
+    };
+}  // namespace esphome::luxtronik_v1

--- a/components/luxtronik_v1/simple_timer.h
+++ b/components/luxtronik_v1/simple_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Jens-Uwe Rossbach
+ * Copyright (c) 2024-2025 Jens-Uwe Rossbach
  *
  * This code is licensed under the MIT License.
  *
@@ -52,6 +52,11 @@ namespace esphome::luxtronik_v1
             m_callback = std::move(cb);
 
             m_running = true;
+        }
+
+        bool is_running() const
+        {
+            return m_running;
         }
 
         bool cancel()

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -63,6 +63,7 @@ uart:
 
 # Luxtronik V1 component (mandatory)
 luxtronik_v1:
+  id: luxtronik_heat_pump
   uart_id: uart_bus
 
 # numeric sensors (not needed sensors can be removed)
@@ -289,3 +290,29 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: IP Adresse
+
+number:
+  # number input for setting hot water set temperature
+  - platform: template
+    id: hot_water_set_temperature_value
+    name: Soll-Temperatur Brauchwarmwasser
+    icon: mdi:coolant-temperature
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    min_value: 20.0
+    max_value: 65.0
+    step: 0.5
+
+button:
+  # button for sending hot water set temperature to Luxtronik heating control unit
+  - platform: template
+    name: Brauchwarmwasser Soll-Temperatur setzen
+    icon: mdi:download
+    entity_category: config
+    on_press:
+      - luxtronik_v1.set_hot_water_set_temperature:
+          id: luxtronik_heat_pump
+          value: !lambda "return id(hot_water_set_temperature_value).state;"


### PR DESCRIPTION
Adds the possibility to change the hot water set temperature configured in the Luxtronik heating control unit. For this purpose, the new action `set_hot_water_set_temperature` has been added. It can be called either from a Home Assistant automation or from some UI element like a number input in combination with a button.

Resolves #25