### PR TITLE
Possibility to change the heating curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ text_sensor:
 ### Actions
 The Luxtronik component provides actions for programming the Luxtronik heating control unit.
 
-#### Set Energy Meter
+#### Set Hot Water Set Temperature
 | Action | Description |
 | ------ | ----------- |
 | `luxtronik_v1.set_hot_water_set_temperature` | Sets the hot water set temperature to the given value |

--- a/README.md
+++ b/README.md
@@ -212,15 +212,15 @@ Die folgenden numerischen Sensoren können konfiguriert werden:
 | `mixed_circuit_1_temperature` | `temperature` | 1100 | Ist-Temperatur Vorlauf Mischkreis 1 |
 | `mixed_circuit_1_set_temperature` | `temperature` | 1100 | Soll-Temperatur Vorlauf Mischkreis 1 |
 | `remote_adjuster_temperature` | `temperature` | 1100 | Temperatur Raumfernversteller |
-| `heating_curve_hc_return_offset` | `temperature` | 3400 | Abweichung Rücklauf-Temperatur zu der der Heizkreis-Heizkurve |
-| `heating_curve_hc_endpoint` | `temperature` | 3400 | Heizkurve Heizkreis Endpunkt |
-| `heating_curve_hc_parallel_shift` | `temperature` | 3400 | Heizkurve Heizkreis Parallelverschiebung |
-| `heating_curve_hc_night_setback` | `temperature` | 3400 | Heizkurve Heizkreis Nachtabsenkung |
-| `heating_curve_hc_constant_return` | `temperature` | 3400 | Heizkurve Heizkreis Festwert Rücklauf |
-| `heating_curve_mc1_endpoint` | `temperature` | 3400 | Heizkurve Mischkreis 1 Endpunkt |
-| `heating_curve_mc1_parallel_shift` | `temperature` | 3400 | Heizkurve Mischkreis 1 Parallelverschiebung |
-| `heating_curve_mc1_night_setback` | `temperature` | 3400 | Heizkurve Mischkreis 1 Nachtabsenkung |
-| `heating_curve_mc1_constant_flow` | `temperature` | 3400 | Heizkurve Mischkreis 1 Festwert Vorlauf |
+| `heating_curve_hc_return_offset` | `temperature` | 3400 | Abweichung der Rücklauf-Temperatur zu der Temperatur der Heizkreis-Heizkurve |
+| `heating_curve_hc_endpoint` | `temperature` | 3400 | Endpunkt der Heizkreis-Heizkurve |
+| `heating_curve_hc_parallel_shift` | `temperature` | 3400 | Parallelverschiebung der Heizkreis-Heizkurve |
+| `heating_curve_hc_night_setback` | `temperature` | 3400 | Nachtabsenkung der Heizkreis-Heizkurve |
+| `heating_curve_hc_constant_return` | `temperature` | 3400 | Festwert für den Rücklauf des Heizkreises |
+| `heating_curve_mc1_endpoint` | `temperature` | 3400 | Endpunkt der Mischkreis-1-Heizkurve |
+| `heating_curve_mc1_parallel_shift` | `temperature` | 3400 | Parallelverschiebung der Mischkreis-1-Heizkurve |
+| `heating_curve_mc1_night_setback` | `temperature` | 3400 | Nachtabsenkung der Mischkreis-1-Heizkurve |
+| `heating_curve_mc1_constant_flow` | `temperature` | 3400 | Festwert für den Vorlauf des Mischkreises 1 |
 | `impulses_compressor_1` | - | 1450 |  Impulse Verdichter 1 |
 | `impulses_compressor_2` | - | 1450 |  Impulse Verdichter 2 |
 
@@ -448,6 +448,28 @@ Die Luxtronik-Komponente stellt Aktionen zur Verfügung, um die Luxtronik Heizun
 | `value` | `float` | 0.0&nbsp;...&nbsp;99.0 | Zielwert für die Soll-Temperatur des Brauchwarmwassers in °C |
 
 Anstelle eines festen Zahlenwerts kann auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Wert zurückgibt.
+
+#### Heizkurven setzen
+| Aktion | Beschreibung |
+| ------ | ------------ |
+| `luxtronik_v1.set_heating_curves` | Setzt einige oder alle Aspekte der Heizkurven |
+
+##### Parameter
+| Parameter | Typ | Bereich | Beschreibung |
+| --------- | --- | ------- | ------------ |
+| `hc_return_offset` | `float` | -5.0&nbsp;...&nbsp;5.0 | Abweichung der Rücklauf-Temperatur zu der Temperatur der Heizkreis-Heizkurve in °C |
+| `hc_endpoint` | `float` | >=&nbsp;0.0 | Endpunkt der Heizkreis-Heizkurve in °C |
+| `hc_parallel_shift` | `float` | >=&nbsp;0.0 | Parallelverschiebung der Heizkreis-Heizkurve in °C |
+| `hc_night_setback` | `float` | <=&nbsp;0.0 | Nachtabsenkung der Heizkreis-Heizkurve in °C |
+| `hc_const_return` | `float` | >=&nbsp;0.0 | Festwert für den Rücklauf des Heizkreises in °C |
+| `mc1_endpoint` | `float` | >=&nbsp;0.0 | Endpunkt der Mischkreis-1-Heizkurve in °C |
+| `mc1_parallel_shift` | `float` | >=&nbsp;0.0 | Parallelverschiebung der Mischkreis-1-Heizkurve in °C |
+| `mc1_night_setback` | `float` | <=&nbsp;0.0 | Nachtabsenkung der Mischkreis-1-Heizkurve in °C |
+| `mc1_const_flow` | `float` | >=&nbsp;0.0 | Festwert für den Vorlauf des Mischkreises 1 in °C |
+
+Anstelle eines festen Zahlenwerts kann bei allen Parametern auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Wert zurückgibt.
+
+Alle Parameter sind optional und können weggelassen werden (wobei aber mindestens ein Parameter angegeben werden sollte, damit die Aktion Sinn macht). Fehlende Werte werden durch die aktuellen Werte der entsprechenden Sensoren ersetzt. Damit dies funktioniert, müssen alle relevanten Sensoren konfiguriert sein. Solltest du einzelne Sensoren der Heizkurven in deiner Hausautomatisierungs-Software nicht benötigen, deklariere sie in diesem Fall als "intern" statt sie aus der Konfiguration zu löschen (siehe Konfigurationsvariable `internal` in der Dokumentation der [ESPHome Sensorkomponenten](https://www.esphome.io/components/sensor)).
 
 ## Luxtronik-Konfiguration
 Um die serielle Schnittstelle des Luxtronik V1 Heizungssteuergeräts nutzen zu können, muss diese zunächst freigeschaltet werden. Dazu musst du im Menü der Luxtronik Benutzerschnittstelle zu _Service_ -> _Einstellungen_ -> _Datenzugang_ navigieren und die PIN `9445` eingeben. Daraufhin navigiere zu _Service_ -> _Diagnoseprogramme_ und aktiviere die Option "Standard".
@@ -897,6 +919,28 @@ The Luxtronik component provides actions for programming the Luxtronik heating c
 | `value` | `float` | 0.0&nbsp;...&nbsp;99.0 | Target value for the hot water set temperature in °C |
 
 Instead of a fixed numeric value, it is also possible to specify a lambda expression that returns the value to be passed to the action.
+
+#### Set Heating Curves
+| Action | Description |
+| ------ | ----------- |
+| `luxtronik_v1.set_heating_curves` | Sets some or all aspects of the heating curves |
+
+##### Parameter
+| Parameter | Type | Range | Description |
+| --------- | ---- | ----- | ----------- |
+| `hc_return_offset` | `float` | -5.0&nbsp;...&nbsp;5.0 | Offset of the return temperature to that of the heat cuircuit heating curve in °C |
+| `hc_endpoint` | `float` | >=&nbsp;0.0 | Heating curve heat cuircuit endpoint in °C |
+| `hc_parallel_shift` | `float` | >=&nbsp;0.0 | Heating curve heat cuircuit parallel shift in °C |
+| `hc_night_setback` | `float` | <=&nbsp;0.0 | Heating curve heat cuircuit night setback in °C |
+| `hc_const_return` | `float` | >=&nbsp;0.0 | Heating curve heat cuircuit constant return in °C |
+| `mc1_endpoint` | `float` | >=&nbsp;0.0 | Heating curve mixed circuit 1 endpoint in °C |
+| `mc1_parallel_shift` | `float` | >=&nbsp;0.0 | Heating curve mixed circuit 1 parallel shift in °C |
+| `mc1_night_setback` | `float` | <=&nbsp;0.0 | Heating curve mixed circuit 1 night setback in °C |
+| `mc1_const_flow` | `float` | >=&nbsp;0.0 | Heating curve mixed circuit 1 constant flow in °C |
+
+Instead of a fixed numerical value, lambda expressions can also be used for all parameters, which return the value to be passed.
+
+All parameters are optional and can be omitted (although at least one parameter should be specified for the action to make sense). Missing values are substituted by the current values of the corresponding sensors. For this to work, all affected sensors must be configured. If you do not require individual sensors of the heating curves in your home automation software, declared them as "internal" instead of removing them from the configuration in this case (see configuration variable `internal` in the documentation of the [ESPHome sensor components](https://www.esphome.io/components/sensor)).
 
 ## Luxtronik Configuration
 In order to use the serial interface of the Luxtronik V1 heating control unit, it needs to be unlocked first. To do this, navigate to _Service_ -> _Einstellungen_ -> _Datenzugang_ and enter the PIN `9445`. After that, navigate to _Service_ -> _Diagnoseprogramme_ and activate the option "Standard".

--- a/README.md
+++ b/README.md
@@ -212,12 +212,12 @@ Die folgenden numerischen Sensoren können konfiguriert werden:
 | `mixed_circuit_1_temperature` | `temperature` | 1100 | Ist-Temperatur Vorlauf Mischkreis 1 |
 | `mixed_circuit_1_set_temperature` | `temperature` | 1100 | Soll-Temperatur Vorlauf Mischkreis 1 |
 | `remote_adjuster_temperature` | `temperature` | 1100 | Temperatur Raumfernversteller |
-| `heating_curve_offset` | `temperature` | 3400 | Abweichung Heizkurve |
-| `heating_curve_endpoint` | `temperature` | 3400 | Heizkurve Endpunkt |
-| `heating_curve_parallel_shift` | `temperature` | 3400 | Heizkurve Parallelverschiebung |
-| `heating_curve_night_setback` | `temperature` | 3400 | Heizkurve Nachtabsenkung |
-| `heating_curve_constant_return` | `temperature` | 3400 | Heizkurve Festwert Rücklauf |
-| `heating_curve_mc1_end_point` | `temperature` | 3400 | Heizkurve Mischkreis 1 Endpunkt |
+| `heating_curve_hc_return_offset` | `temperature` | 3400 | Abweichung Rücklauf-Temperatur zu der der Heizkreis-Heizkurve |
+| `heating_curve_hc_endpoint` | `temperature` | 3400 | Heizkurve Heizkreis Endpunkt |
+| `heating_curve_hc_parallel_shift` | `temperature` | 3400 | Heizkurve Heizkreis Parallelverschiebung |
+| `heating_curve_hc_night_setback` | `temperature` | 3400 | Heizkurve Heizkreis Nachtabsenkung |
+| `heating_curve_hc_constant_return` | `temperature` | 3400 | Heizkurve Heizkreis Festwert Rücklauf |
+| `heating_curve_mc1_endpoint` | `temperature` | 3400 | Heizkurve Mischkreis 1 Endpunkt |
 | `heating_curve_mc1_parallel_shift` | `temperature` | 3400 | Heizkurve Mischkreis 1 Parallelverschiebung |
 | `heating_curve_mc1_night_setback` | `temperature` | 3400 | Heizkurve Mischkreis 1 Nachtabsenkung |
 | `heating_curve_mc1_constant_flow` | `temperature` | 3400 | Heizkurve Mischkreis 1 Festwert Vorlauf |
@@ -662,12 +662,12 @@ The following numeric sensors can be configured:
 | `mixed_circuit_1_temperature` | `temperature` | 1100 | Temperature of mixed circuit 1 |
 | `mixed_circuit_1_set_temperature` | `temperature` | 1100 | Set-emperature of mixed circuit 1 |
 | `remote_adjuster_temperature` | `temperature` | 1100 | Temperature of the remote adjuster |
-| `heating_curve_offset` | `temperature` | 3400 | Offset heating curve |
-| `heating_curve_endpoint` | `temperature` | 3400 | Heating curve endpoint |
-| `heating_curve_parallel_shift` | `temperature` | 3400 | Heating curve parallel shift |
-| `heating_curve_night_setback` | `temperature` | 3400 | Heating curve night setback |
-| `heating_curve_constant_return` | `temperature` | 3400 | Heating curve constant return |
-| `heating_curve_mc1_end_point` | `temperature` | 3400 | Heating curve mixed circuit 1 endpoint |
+| `heating_curve_hc_return_offset` | `temperature` | 3400 | Offset return temperature to that of heat cuircuit heating curve |
+| `heating_curve_hc_endpoint` | `temperature` | 3400 | Heating curve heat cuircuit endpoint |
+| `heating_curve_hc_parallel_shift` | `temperature` | 3400 | Heating curve heat cuircuit parallel shift |
+| `heating_curve_hc_night_setback` | `temperature` | 3400 | Heating curve heat cuircuit night setback |
+| `heating_curve_hc_constant_return` | `temperature` | 3400 | Heating curve heat cuircuit constant return |
+| `heating_curve_mc1_endpoint` | `temperature` | 3400 | Heating curve mixed circuit 1 endpoint |
 | `heating_curve_mc1_parallel_shift` | `temperature` | 3400 | Heating curve mixed circuit 1 parallel shift |
 | `heating_curve_mc1_night_setback` | `temperature` | 3400 | Heating curve mixed circuit 1 night setback |
 | `heating_curve_mc1_constant_flow` | `temperature` | 3400 | Heating curve mixed circuit 1 constant flow |

--- a/components/luxtronik_v1/__init__.py
+++ b/components/luxtronik_v1/__init__.py
@@ -42,10 +42,21 @@ CONF_RESPONSE_TIMEOUT = "response_timeout"
 CONF_MAX_RETRIES      = "max_retries"
 CONF_INCLUDE_DATASETS = "include_datasets"
 
+CONF_HC_RETURN_OFFSET   = "hc_return_offset"
+CONF_HC_ENDPOINT        = "hc_endpoint"
+CONF_HC_PARALLEL_SHIFT  = "hc_parallel_shift"
+CONF_HC_NIGHT_SETBACK   = "hc_night_setback"
+CONF_HC_CONST_RETURN    = "hc_const_return"
+CONF_MC1_ENDPOINT       = "mc1_endpoint"
+CONF_MC1_PARALLEL_SHIFT = "mc1_parallel_shift"
+CONF_MC1_NIGHT_SETBACK  = "mc1_night_setback"
+CONF_MC1_CONST_FLOW     = "mc1_const_flow"
+
 
 luxtronik_ns = cg.esphome_ns.namespace("luxtronik_v1")
 Luxtronik = luxtronik_ns.class_("Luxtronik", cg.PollingComponent)
 SetHotWaterSetTemperatureAction = luxtronik_ns.class_("SetHotWaterSetTemperatureAction", automation.Action)
+SetHeatingCurvesAction = luxtronik_ns.class_("SetHeatingCurvesAction", automation.Action)
 
 def unique_list(value):
     if len(value) != len(set(value)):
@@ -95,5 +106,55 @@ async def set_hot_water_set_temperature_action_to_code(config, action_id, templa
 
     tmpl = await cg.templatable(config[CONF_VALUE], args, float)
     cg.add(act.set_hot_water_set_temperature_value(tmpl))
+
+    return act
+
+@automation.register_action(
+    "luxtronik_v1.set_heating_curves",
+    SetHeatingCurvesAction,
+    cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(Luxtronik),
+        cv.Optional(CONF_HC_RETURN_OFFSET): cv.templatable(cv.float_range(min = -5.0, max = 5.0)),
+        cv.Optional(CONF_HC_ENDPOINT): cv.templatable(cv.positive_float),
+        cv.Optional(CONF_HC_PARALLEL_SHIFT): cv.templatable(cv.positive_float),
+        cv.Optional(CONF_HC_NIGHT_SETBACK): cv.templatable(cv.float_range(max = 0.0)),
+        cv.Optional(CONF_HC_CONST_RETURN): cv.templatable(cv.positive_float),
+        cv.Optional(CONF_MC1_ENDPOINT): cv.templatable(cv.positive_float),
+        cv.Optional(CONF_MC1_PARALLEL_SHIFT): cv.templatable(cv.positive_float),
+        cv.Optional(CONF_MC1_NIGHT_SETBACK): cv.templatable(cv.float_range(max = 0.0)),
+        cv.Optional(CONF_MC1_CONST_FLOW): cv.templatable(cv.positive_float)
+    }))
+async def set_heating_curves_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    act = cg.new_Pvariable(action_id, template_arg, parent)
+
+    if CONF_HC_RETURN_OFFSET in config:
+        tmpl = await cg.templatable(config[CONF_HC_RETURN_OFFSET], args, float)
+        cg.add(act.set_heating_curve_hc_return_offset_value(tmpl))
+    if CONF_HC_ENDPOINT in config:
+        tmpl = await cg.templatable(config[CONF_HC_ENDPOINT], args, float)
+        cg.add(act.set_heating_curve_hc_endpoint_value(tmpl))
+    if CONF_HC_PARALLEL_SHIFT in config:
+        tmpl = await cg.templatable(config[CONF_HC_PARALLEL_SHIFT], args, float)
+        cg.add(act.set_heating_curve_hc_parallel_shift_value(tmpl))
+    if CONF_HC_NIGHT_SETBACK in config:
+        tmpl = await cg.templatable(config[CONF_HC_NIGHT_SETBACK], args, float)
+        cg.add(act.set_heating_curve_hc_night_setback_value(tmpl))
+    if CONF_HC_CONST_RETURN in config:
+        tmpl = await cg.templatable(config[CONF_HC_CONST_RETURN], args, float)
+        cg.add(act.set_heating_curve_hc_constant_return_value(tmpl))
+    if CONF_MC1_ENDPOINT in config:
+        tmpl = await cg.templatable(config[CONF_MC1_ENDPOINT], args, float)
+        cg.add(act.set_heating_curve_mc1_endpoint_value(tmpl))
+    if CONF_MC1_PARALLEL_SHIFT in config:
+        tmpl = await cg.templatable(config[CONF_MC1_PARALLEL_SHIFT], args, float)
+        cg.add(act.set_heating_curve_mc1_parallel_shift_value(tmpl))
+    if CONF_MC1_NIGHT_SETBACK in config:
+        tmpl = await cg.templatable(config[CONF_MC1_NIGHT_SETBACK], args, float)
+        cg.add(act.set_heating_curve_mc1_night_setback_value(tmpl))
+    if CONF_MC1_CONST_FLOW in config:
+        tmpl = await cg.templatable(config[CONF_MC1_CONST_FLOW], args, float)
+        cg.add(act.set_heating_curve_mc1_constant_flow_value(tmpl))
 
     return act

--- a/components/luxtronik_v1/automation.h
+++ b/components/luxtronik_v1/automation.h
@@ -56,4 +56,104 @@ namespace esphome::luxtronik_v1
         Luxtronik *m_luxtronik;
         TemplatableValue<float, Ts...> m_set_temperature_value;
     };
+
+    template<typename... Ts> class SetHeatingCurvesAction : public Action<Ts...>
+    {
+    public:
+    SetHeatingCurvesAction(Luxtronik *luxtronik)
+            : m_luxtronik(luxtronik)
+            , m_hc_return_offset_value()
+            , m_hc_endpoint_value()
+            , m_hc_parallel_shift_value()
+            , m_hc_night_setback_value()
+            , m_hc_const_return_value()
+            , m_mc1_endpoint_value()
+            , m_mc1_parallel_shift_value()
+            , m_mc1_night_setback_value()
+            , m_mc1_const_flow_value()
+        {
+        }
+
+        void play(Ts... x) override
+        {
+            Luxtronik::HeatingCurves heating_curves;
+            heating_curves.hc_return_offset_avail = m_hc_return_offset_value.has_value();
+            heating_curves.hc_return_offset = m_hc_return_offset_value.value(x...);
+            heating_curves.hc_endpoint_avail = m_hc_endpoint_value.has_value();
+            heating_curves.hc_endpoint = m_hc_endpoint_value.value(x...);
+            heating_curves.hc_parallel_shift_avail = m_hc_parallel_shift_value.has_value();
+            heating_curves.hc_parallel_shift = m_hc_parallel_shift_value.value(x...);
+            heating_curves.hc_night_setback_avail = m_hc_night_setback_value.has_value();
+            heating_curves.hc_night_setback = m_hc_night_setback_value.value(x...);
+            heating_curves.hc_const_return_avail = m_hc_const_return_value.has_value();
+            heating_curves.hc_const_return = m_hc_const_return_value.value(x...);
+            heating_curves.mc1_endpoint_avail = m_mc1_endpoint_value.has_value();
+            heating_curves.mc1_endpoint = m_mc1_endpoint_value.value(x...);
+            heating_curves.mc1_parallel_shift_avail = m_mc1_parallel_shift_value.has_value();
+            heating_curves.mc1_parallel_shift = m_mc1_parallel_shift_value.value(x...);
+            heating_curves.mc1_night_setback_avail = m_mc1_night_setback_value.has_value();
+            heating_curves.mc1_night_setback = m_mc1_night_setback_value.value(x...);
+            heating_curves.mc1_const_flow_avail = m_mc1_const_flow_value.has_value();
+            heating_curves.mc1_const_flow = m_mc1_const_flow_value.value(x...);
+
+            m_luxtronik->set_heating_curves(heating_curves);
+        }
+
+        template<typename V> void set_heating_curve_hc_return_offset_value(V value)
+        {
+            m_hc_return_offset_value = value;
+        }
+
+        template<typename V> void set_heating_curve_hc_endpoint_value(V value)
+        {
+            m_hc_endpoint_value = value;
+        }
+
+        template<typename V> void set_heating_curve_hc_parallel_shift_value(V value)
+        {
+            m_hc_parallel_shift_value = value;
+        }
+
+        template<typename V> void set_heating_curve_hc_night_setback_value(V value)
+        {
+            m_hc_night_setback_value = value;
+        }
+
+        template<typename V> void set_heating_curve_hc_constant_return_value(V value)
+        {
+            m_hc_const_return_value = value;
+        }
+
+        template<typename V> void set_heating_curve_mc1_endpoint_value(V value)
+        {
+            m_mc1_endpoint_value = value;
+        }
+
+        template<typename V> void set_heating_curve_mc1_parallel_shift_value(V value)
+        {
+            m_mc1_parallel_shift_value = value;
+        }
+
+        template<typename V> void set_heating_curve_mc1_night_setback_value(V value)
+        {
+            m_mc1_night_setback_value = value;
+        }
+
+        template<typename V> void set_heating_curve_mc1_constant_flow_value(V value)
+        {
+            m_mc1_const_flow_value = value;
+        }
+
+    protected:
+        Luxtronik *m_luxtronik;
+        TemplatableValue<float, Ts...> m_hc_return_offset_value;
+        TemplatableValue<float, Ts...> m_hc_endpoint_value;
+        TemplatableValue<float, Ts...> m_hc_parallel_shift_value;
+        TemplatableValue<float, Ts...> m_hc_night_setback_value;
+        TemplatableValue<float, Ts...> m_hc_const_return_value;
+        TemplatableValue<float, Ts...> m_mc1_endpoint_value;
+        TemplatableValue<float, Ts...> m_mc1_parallel_shift_value;
+        TemplatableValue<float, Ts...> m_mc1_night_setback_value;
+        TemplatableValue<float, Ts...> m_mc1_const_flow_value;
+    };
 }  // namespace esphome::ferraris

--- a/components/luxtronik_v1/automation.h
+++ b/components/luxtronik_v1/automation.h
@@ -38,6 +38,7 @@ namespace esphome::luxtronik_v1
     public:
     SetHotWaterSetTemperatureAction(Luxtronik *luxtronik)
             : m_luxtronik(luxtronik)
+            , m_set_temperature_value()
         {
         }
 

--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -162,12 +162,12 @@ namespace esphome::luxtronik_v1
         , m_sensor_firmware_version()
         , m_sensor_bivalence_level()
         , m_sensor_operational_state()
-        , m_sensor_heating_curve_offset()
-        , m_sensor_heating_curve_endpoint()
-        , m_sensor_heating_curve_parallel_shift()
-        , m_sensor_heating_curve_night_setback()
-        , m_sensor_heating_curve_constant_return()
-        , m_sensor_heating_curve_mc1_end_point()
+        , m_sensor_heating_curve_hc_return_offset()
+        , m_sensor_heating_curve_hc_endpoint()
+        , m_sensor_heating_curve_hc_parallel_shift()
+        , m_sensor_heating_curve_hc_night_setback()
+        , m_sensor_heating_curve_hc_constant_return()
+        , m_sensor_heating_curve_mc1_endpoint()
         , m_sensor_heating_curve_mc1_parallel_shift()
         , m_sensor_heating_curve_mc1_night_setback()
         , m_sensor_heating_curve_mc1_constant_flow()
@@ -365,12 +365,12 @@ namespace esphome::luxtronik_v1
         LOG_STRING_SENSOR("Operational State Sensor", m_sensor_operational_state);
         LOG_STRING_SENSOR("Mixer 1 Sensor", m_sensor_mixer_1_state);
 
-        LOG_TEMPERATURE_SENSOR("Heating Curve Offset Sensor", m_sensor_heating_curve_offset);
-        LOG_TEMPERATURE_SENSOR("Heating Curve Endpoint Sensor", m_sensor_heating_curve_endpoint);
-        LOG_TEMPERATURE_SENSOR("Heating Curve Parallel Shift Sensor", m_sensor_heating_curve_parallel_shift);
-        LOG_TEMPERATURE_SENSOR("Heating Curve Night Setback Sensor", m_sensor_heating_curve_night_setback);
-        LOG_TEMPERATURE_SENSOR("Heating Curve Constant Return Sensor", m_sensor_heating_curve_constant_return);
-        LOG_TEMPERATURE_SENSOR("Heating Curve MC1 Endpoint Sensor", m_sensor_heating_curve_mc1_end_point);
+        LOG_TEMPERATURE_SENSOR("Heating Curve HC Return Offset Sensor", m_sensor_heating_curve_hc_return_offset);
+        LOG_TEMPERATURE_SENSOR("Heating Curve HC Endpoint Sensor", m_sensor_heating_curve_hc_endpoint);
+        LOG_TEMPERATURE_SENSOR("Heating Curve HC Parallel Shift Sensor", m_sensor_heating_curve_hc_parallel_shift);
+        LOG_TEMPERATURE_SENSOR("Heating Curve HC Night Setback Sensor", m_sensor_heating_curve_hc_night_setback);
+        LOG_TEMPERATURE_SENSOR("Heating Curve HC Constant Return Sensor", m_sensor_heating_curve_hc_constant_return);
+        LOG_TEMPERATURE_SENSOR("Heating Curve MC1 Endpoint Sensor", m_sensor_heating_curve_mc1_endpoint);
         LOG_TEMPERATURE_SENSOR("Heating Curve MC1 Parallel Shift Sensor", m_sensor_heating_curve_mc1_parallel_shift);
         LOG_TEMPERATURE_SENSOR("Heating Curve MC1 Night Setback Sensor", m_sensor_heating_curve_mc1_night_setback);
         LOG_TEMPERATURE_SENSOR("Heating Curve MC1 Constant Flow Sensor", m_sensor_heating_curve_mc1_constant_flow);
@@ -862,27 +862,27 @@ namespace esphome::luxtronik_v1
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_offset.set_state(response, start, end);
+            m_sensor_heating_curve_hc_return_offset.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_endpoint.set_state(response, start, end);
+            m_sensor_heating_curve_hc_endpoint.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_parallel_shift.set_state(response, start, end);
+            m_sensor_heating_curve_hc_parallel_shift.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_night_setback.set_state(response, start, end);
+            m_sensor_heating_curve_hc_night_setback.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_constant_return.set_state(response, start, end);
+            m_sensor_heating_curve_hc_constant_return.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_mc1_end_point.set_state(response, start, end);
+            m_sensor_heating_curve_mc1_endpoint.set_state(response, start, end);
 
             start = end + 1;
             end = response.find(DELIMITER, start);

--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -35,25 +35,27 @@ namespace esphome::luxtronik_v1
 {
     static constexpr const char *const TAG = "luxtronik";
 
-    static constexpr const char* const TYPE_TEMPERATURES       = "1100";
-    static constexpr const char* const TYPE_INPUTS             = "1200";
-    static constexpr const char* const TYPE_OUTPUTS            = "1300";
-    static constexpr const char* const TYPE_OPERATING_HOURS    = "1450";
-    static constexpr const char* const TYPE_ERRORS             = "1500";
-    static constexpr const char* const TYPE_ERRORS_SLOT        = "1500;150";
-    static constexpr const char* const TYPE_DEACTIVATIONS      = "1600";
-    static constexpr const char* const TYPE_DEACTIVATIONS_SLOT = "1600;160";
-    static constexpr const char* const TYPE_INFORMATION        = "1700";
-    static constexpr const char* const TYPE_ALL                = "1800";
-    static constexpr const char* const TYPE_HEATING_CURVE      = "3400";
-    static constexpr const char* const TYPE_HEATING_MODE       = "3405";
-    static constexpr const char* const TYPE_HOT_WATER_CONFIG   = "3501";
-    static constexpr const char* const TYPE_HOT_WATER_MODE     = "3505";
+    static constexpr const char* const TYPE_TEMPERATURES          = "1100";
+    static constexpr const char* const TYPE_INPUTS                = "1200";
+    static constexpr const char* const TYPE_OUTPUTS               = "1300";
+    static constexpr const char* const TYPE_OPERATING_HOURS       = "1450";
+    static constexpr const char* const TYPE_ERRORS                = "1500";
+    static constexpr const char* const TYPE_ERRORS_SLOT           = "1500;150";
+    static constexpr const char* const TYPE_DEACTIVATIONS         = "1600";
+    static constexpr const char* const TYPE_DEACTIVATIONS_SLOT    = "1600;160";
+    static constexpr const char* const TYPE_INFORMATION           = "1700";
+    static constexpr const char* const TYPE_ALL                   = "1800";
+    static constexpr const char* const TYPE_HEATING_CURVES        = "3400";
+    static constexpr const char* const TYPE_HEATING_CURVES_CONFIG = "3401";
+    static constexpr const char* const TYPE_HEATING_MODE          = "3405";
+    static constexpr const char* const TYPE_HOT_WATER_CONFIG      = "3501";
+    static constexpr const char* const TYPE_HOT_WATER_MODE        = "3505";
 
     static constexpr const char* const TYPE_STORE_CONFIG      = "999";
     static constexpr const char* const TYPE_STORE_CONFIG_ACK  = "993";
     static constexpr const char* const TYPE_STORE_CONFIG_SEQ  = "999993993999";
-    static constexpr const char* const TYPE_NACK              = "778";
+    static constexpr const char* const TYPE_NACK_778          = "778";
+    static constexpr const char* const TYPE_NACK_779          = "779";
 
     static constexpr const char ASCII_CR      = 0x0D;  // cariage return ('\r')
     static constexpr const char ASCII_LF      = 0x0A;  // line feed ('\n')
@@ -492,7 +494,7 @@ namespace esphome::luxtronik_v1
 
         if ((response == TYPE_STORE_CONFIG) || (response == TYPE_STORE_CONFIG_ACK))
         {
-            ack_response();
+            accept_response();
             m_store_config_ack += response;
             m_config_response_state = 0;
 
@@ -512,6 +514,7 @@ namespace esphome::luxtronik_v1
                             {
                                 ESP_LOGW(TAG, "No full acknowledge received after storing configuration");
 
+                                m_store_config_ack = "";
                                 m_request_queue.pop_front();
                                 request_data();
                             });
@@ -519,480 +522,65 @@ namespace esphome::luxtronik_v1
         }
         else if (starts_with(response, TYPE_TEMPERATURES))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_flow_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_return_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_return_set_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_hot_gas_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_outside_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_hot_water_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_hot_water_set_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heat_source_input_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heat_source_output_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_mixed_circuit_1_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_mixed_circuit_1_set_temperature.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_remote_adjuster_temperature.set_state(response, start, end);
-
-            next_dataset();
+            parse_temperatures(response);
         }
         else if (starts_with(response, TYPE_INPUTS))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_defrost_brine_flow.set_state(response, start, end);  // on = defrost ending or flow rate ok (depending on device type)
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_power_provider_lock_period.set_state(response, start, end);  // off = lock period, on = not locked
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_high_pressure_state.set_state(response, start, end);  // off = pressure ok, on = not ok
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_engine_protection.set_state(response, start, end, true);  // on = engine protection ok, off = not ok
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_low_pressure_state.set_state(response, start, end, true);  // on = pressure ok, off = not ok
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_external_power.set_state(response, start, end);
-
-            next_dataset();
+            parse_inputs(response);
         }
         else if (starts_with(response, TYPE_OUTPUTS))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_defrost_valve.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_hot_water_pump.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_floor_heating_pump.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_pump.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            bool mixerOpen = get_binary_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            bool mixerClose = get_binary_state(response, start, end);
-
-            // merge the two separate states (Mischer 1 fährt auf, Mischer 1 fährt zu) into one sensor
-            m_sensor_mixer_1_state.set_state(
-                    mixerOpen
-                        ? "opening"
-                        : mixerClose
-                            ? "closing"
-                            : "idle");
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_housing_ventilation.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_ventilation_pump.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_compressor_1.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_compressor_2.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_extra_pump.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_secondary_heater_1.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_secondary_heater_2_failure.set_state(response, start, end);
-
-            next_dataset();
+            parse_outputs(response);
         }
         else if (starts_with(response, TYPE_OPERATING_HOURS))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_operating_hours_compressor_1.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_impulses_compressor_1.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_average_operating_time_compressor_1.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_operating_hours_compressor_2.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_impulses_compressor_2.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_average_operating_time_compressor_2.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_operating_hours_secondary_heater_1.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_operating_hours_secondary_heater_2.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_operating_hours_heat_pump.set_state(response, start, end);
-
-            next_dataset();
+            parse_operating_hours(response);
         }
         else if (starts_with(response, TYPE_ERRORS))
         {
-            ack_response();
-
-            if ((response.length() >= MIN_SLOT_LENGTH) && starts_with(response, TYPE_ERRORS_SLOT))
-            {
-                char slotID = response.at(INDEX_SLOT_ID);
-                switch (slotID)
-                {
-                    case SLOT_1_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_1_code, m_sensor_error_1_time); break; }
-                    case SLOT_2_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_2_code, m_sensor_error_2_time); break; }
-                    case SLOT_3_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_3_code, m_sensor_error_3_time); break; }
-                    case SLOT_4_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_4_code, m_sensor_error_4_time); break; }
-                    case SLOT_5_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_5_code, m_sensor_error_5_time); break; }
-                }
-            }
-            else if (!m_slot_block)
-            {
-                m_slot_block = true;
-            }
-            else
-            {
-                m_slot_block = false;
-                next_dataset();
-            }
+            parse_errors(response);
         }
         else if (starts_with(response, TYPE_DEACTIVATIONS))
         {
-            ack_response();
-
-            if ((response.length() >= MIN_SLOT_LENGTH) && starts_with(response, TYPE_DEACTIVATIONS_SLOT))
-            {
-                char slotID = response.at(INDEX_SLOT_ID);
-                switch (slotID)
-                {
-                    case SLOT_1_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_1_code, m_sensor_deactivation_1_time); break; }
-                    case SLOT_2_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_2_code, m_sensor_deactivation_2_time); break; }
-                    case SLOT_3_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_3_code, m_sensor_deactivation_3_time); break; }
-                    case SLOT_4_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_4_code, m_sensor_deactivation_4_time); break; }
-                    case SLOT_5_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_5_code, m_sensor_deactivation_5_time); break; }
-                }
-            }
-            else if (!m_slot_block)
-            {
-                m_slot_block = true;
-            }
-            else
-            {
-                m_slot_block = false;
-                next_dataset();
-            }
+            parse_deactivations(response);
         }
         else if (starts_with(response, TYPE_INFORMATION))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-
-            if (m_sensor_device_type.has_sensor())
-            {
-                std::string state = "";
-                int32_t value = get_number(response, start, end);
-
-                switch (static_cast<DeviceType>(value))
-                {
-                    case DeviceType::ERC: { state = "ERC";                 break; }
-                    case DeviceType::SW1: { state = "SW1";                 break; }
-                    case DeviceType::SW2: { state = "SW2";                 break; }
-                    case DeviceType::WW1: { state = "WW1";                 break; }
-                    case DeviceType::WW2: { state = "WW2";                 break; }
-                    case DeviceType::L1I: { state = "L1I";                 break; }
-                    case DeviceType::L2I: { state = "L2I";                 break; }
-                    case DeviceType::L1A: { state = "L1A";                 break; }
-                    case DeviceType::L2A: { state = "L2A";                 break; }
-                    case DeviceType::KSW: { state = "KSW";                 break; }
-                    case DeviceType::KLW: { state = "KLW";                 break; }
-                    case DeviceType::SWC: { state = "SWC";                 break; }
-                    case DeviceType::LWC: { state = "LWC";                 break; }
-                    case DeviceType::L2G: { state = "L2G";                 break; }
-                    case DeviceType::WZS: { state = "WZS";                 break; }
-                    default:              { state = std::to_string(value); break; }
-                }
-
-                m_sensor_device_type.set_state(state);
-            }
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_firmware_version.set_state(response, start + 1, end);  // skip leading space
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-
-            if (m_sensor_bivalence_level.has_sensor())
-            {
-                std::string state = "";
-                int32_t value = get_number(response, start, end);
-
-                switch (static_cast<BivalenceLevel>(value))
-                {
-                    case BivalenceLevel::SINGLE_COMPRESSOR: { state = "single_compressor";   break; }
-                    case BivalenceLevel::DUAL_COMPRESSOR:   { state = "dual_compressor";     break; }
-                    case BivalenceLevel::ADDITIONAL_HEATER: { state = "additional_heater";   break; }
-                    default:                                { state = std::to_string(value); break; }
-                }
-
-                m_sensor_bivalence_level.set_state(state);
-            }
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-
-            if (m_sensor_operational_state.has_sensor())
-            {
-                std::string state = "";
-                int32_t value = get_number(response, start, end);
-
-                switch (static_cast<OperationalState>(value))
-                {
-                    case OperationalState::HEAT:          { state = "heat";                break; }
-                    case OperationalState::HOT_WATER:     { state = "hot_water";           break; }
-                    case OperationalState::SWIMMING_POOL: { state = "swimming_pool";       break; }
-                    case OperationalState::PROVIDER_LOCK: { state = "provider_lock";       break; }
-                    case OperationalState::DEFROST:       { state = "defrost";             break; }
-                    case OperationalState::STANDBY:       { state = "standby";             break; }
-                    default:                              { state = std::to_string(value); break; }
-                }
-
-                m_sensor_operational_state.set_state(state);
-            }
-
-            next_dataset();
+            parse_information(response);
         }
-        else if (starts_with(response, TYPE_HEATING_CURVE))
+        else if (starts_with(response, TYPE_HEATING_CURVES))
         {
-            ack_response();
+            parse_heating_curves(response);
+        }
+        else if (starts_with(response, TYPE_HEATING_CURVES_CONFIG))
+        {
+            if (m_config_response_state != 1)  // ignore echo
+            {
+                parse_heating_curves(response);
+            }
 
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_hc_return_offset.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_hc_endpoint.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_hc_parallel_shift.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_hc_night_setback.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_hc_constant_return.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_mc1_endpoint.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_mc1_parallel_shift.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_mc1_night_setback.set_state(response, start, end);
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-            m_sensor_heating_curve_mc1_constant_flow.set_state(response, start, end);
-
-            next_dataset();
+            ++m_config_response_state;
         }
         else if (starts_with(response, TYPE_HEATING_MODE))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-
-            if (m_sensor_heating_mode.has_sensor())
-            {
-                std::string state = "";
-                int32_t value = get_number(response, start, end);
-
-                switch (static_cast<OperationalMode>(value))
-                {
-                    case OperationalMode::AUTO:          { state = "auto";                break; }
-                    case OperationalMode::SECOND_HEATER: { state = "second_heater";       break; }
-                    case OperationalMode::PARTY:         { state = "party";               break; }
-                    case OperationalMode::VACATION:      { state = "vacation";            break; }
-                    case OperationalMode::OFF:           { state = "off";                 break; }
-                    default:                             { state = std::to_string(value); break; }
-                }
-
-                m_sensor_heating_mode.set_state(state);
-            }
-
-            next_dataset();
+            parse_heating_mode(response);
         }
         else if (starts_with(response, TYPE_HOT_WATER_CONFIG))
         {
             if (m_config_response_state != 1)  // ignore echo
             {
-                ack_response();
-
-                size_t start = INDEX_RESPONSE_START;
-                size_t end = response.find(DELIMITER, start);
-                // skip number of elements
-
-                start = end + 1;
-                end = response.find(DELIMITER, start);
-                m_sensor_hot_water_set_temperature.set_state(response, start, end);
-
-                next_dataset();
+                parse_hot_water_config(response);
             }
 
             ++m_config_response_state;
         }
         else if (starts_with(response, TYPE_HOT_WATER_MODE))
         {
-            ack_response();
-
-            size_t start = INDEX_RESPONSE_START;
-            size_t end = response.find(DELIMITER, start);
-            // skip number of elements
-
-            start = end + 1;
-            end = response.find(DELIMITER, start);
-
-            if (m_sensor_hot_water_mode.has_sensor())
-            {
-                std::string state = "";
-                int32_t value = get_number(response, start, end);
-
-                switch (static_cast<OperationalMode>(value))
-                {
-                    case OperationalMode::AUTO:          { state = "auto";                break; }
-                    case OperationalMode::SECOND_HEATER: { state = "second_heater";       break; }
-                    case OperationalMode::PARTY:         { state = "party";               break; }
-                    case OperationalMode::VACATION:      { state = "vacation";            break; }
-                    case OperationalMode::OFF:           { state = "off";                 break; }
-                    default:                             { state = std::to_string(value); break; }
-                }
-
-                m_sensor_hot_water_mode.set_state(state);
-            }
-
-            next_dataset();
+            parse_hot_water_mode(response);
         }
-        else if (starts_with(response, TYPE_NACK))
+        else if (starts_with(response, TYPE_NACK_778))
         {
-            ack_response();
+            accept_response();
 
             size_t start = INDEX_NACK_START;
             size_t end = response.find(DELIMITER, start);
@@ -1006,7 +594,501 @@ namespace esphome::luxtronik_v1
 
             next_dataset();
         }
+        else if (starts_with(response, TYPE_NACK_779))
+        {
+            accept_response();
+
+            size_t start = INDEX_NACK_START;
+            size_t end = response.find(DELIMITER, start);
+
+            std::string cmd = response.substr(start, end - start);
+            ESP_LOGW(TAG, "Request refused during config mode:  REQ %s", cmd.c_str());
+
+            // try again to exit config mode
+            m_request_queue.push_front(TYPE_STORE_CONFIG);
+            request_data();
+        }
     }
+
+    void Luxtronik::parse_temperatures(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_flow_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_return_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_return_set_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_hot_gas_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_outside_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_hot_water_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_hot_water_set_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heat_source_input_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heat_source_output_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_mixed_circuit_1_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_mixed_circuit_1_set_temperature.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_remote_adjuster_temperature.set_state(response, start, end);
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_inputs(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_defrost_brine_flow.set_state(response, start, end);  // on = defrost ending or flow rate ok (depending on device type)
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_power_provider_lock_period.set_state(response, start, end);  // off = lock period, on = not locked
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_high_pressure_state.set_state(response, start, end);  // off = pressure ok, on = not ok
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_engine_protection.set_state(response, start, end, true);  // on = engine protection ok, off = not ok
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_low_pressure_state.set_state(response, start, end, true);  // on = pressure ok, off = not ok
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_external_power.set_state(response, start, end);
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_outputs(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_defrost_valve.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_hot_water_pump.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_floor_heating_pump.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_pump.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        bool mixerOpen = get_binary_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        bool mixerClose = get_binary_state(response, start, end);
+
+        // merge the two separate states (Mischer 1 fährt auf, Mischer 1 fährt zu) into one sensor
+        m_sensor_mixer_1_state.set_state(
+                mixerOpen
+                    ? "opening"
+                    : mixerClose
+                        ? "closing"
+                        : "idle");
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_housing_ventilation.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_ventilation_pump.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_compressor_1.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_compressor_2.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_extra_pump.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_secondary_heater_1.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_secondary_heater_2_failure.set_state(response, start, end);
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_operating_hours(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_operating_hours_compressor_1.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_impulses_compressor_1.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_average_operating_time_compressor_1.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_operating_hours_compressor_2.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_impulses_compressor_2.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_average_operating_time_compressor_2.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_operating_hours_secondary_heater_1.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_operating_hours_secondary_heater_2.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_operating_hours_heat_pump.set_state(response, start, end);
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_errors(const std::string& response)
+    {
+        accept_response();
+
+        if ((response.length() >= MIN_SLOT_LENGTH) && starts_with(response, TYPE_ERRORS_SLOT))
+        {
+            char slotID = response.at(INDEX_SLOT_ID);
+            switch (slotID)
+            {
+                case SLOT_1_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_1_code, m_sensor_error_1_time); break; }
+                case SLOT_2_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_2_code, m_sensor_error_2_time); break; }
+                case SLOT_3_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_3_code, m_sensor_error_3_time); break; }
+                case SLOT_4_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_4_code, m_sensor_error_4_time); break; }
+                case SLOT_5_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_error_5_code, m_sensor_error_5_time); break; }
+            }
+        }
+        else if (!m_slot_block)
+        {
+            m_slot_block = true;
+        }
+        else
+        {
+            m_slot_block = false;
+            next_dataset();
+        }
+    }
+
+    void Luxtronik::parse_deactivations(const std::string& response)
+    {
+        accept_response();
+
+        if ((response.length() >= MIN_SLOT_LENGTH) && starts_with(response, TYPE_DEACTIVATIONS_SLOT))
+        {
+            char slotID = response.at(INDEX_SLOT_ID);
+            switch (slotID)
+            {
+                case SLOT_1_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_1_code, m_sensor_deactivation_1_time); break; }
+                case SLOT_2_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_2_code, m_sensor_deactivation_2_time); break; }
+                case SLOT_3_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_3_code, m_sensor_deactivation_3_time); break; }
+                case SLOT_4_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_4_code, m_sensor_deactivation_4_time); break; }
+                case SLOT_5_ID: { parse_slot(response.substr(INDEX_SLOT_START), m_sensor_deactivation_5_code, m_sensor_deactivation_5_time); break; }
+            }
+        }
+        else if (!m_slot_block)
+        {
+            m_slot_block = true;
+        }
+        else
+        {
+            m_slot_block = false;
+            next_dataset();
+        }
+    }
+
+    void Luxtronik::parse_information(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+
+        if (m_sensor_device_type.has_sensor())
+        {
+            std::string state = "";
+            int32_t value = get_number(response, start, end);
+
+            switch (static_cast<DeviceType>(value))
+            {
+                case DeviceType::ERC: { state = "ERC";                 break; }
+                case DeviceType::SW1: { state = "SW1";                 break; }
+                case DeviceType::SW2: { state = "SW2";                 break; }
+                case DeviceType::WW1: { state = "WW1";                 break; }
+                case DeviceType::WW2: { state = "WW2";                 break; }
+                case DeviceType::L1I: { state = "L1I";                 break; }
+                case DeviceType::L2I: { state = "L2I";                 break; }
+                case DeviceType::L1A: { state = "L1A";                 break; }
+                case DeviceType::L2A: { state = "L2A";                 break; }
+                case DeviceType::KSW: { state = "KSW";                 break; }
+                case DeviceType::KLW: { state = "KLW";                 break; }
+                case DeviceType::SWC: { state = "SWC";                 break; }
+                case DeviceType::LWC: { state = "LWC";                 break; }
+                case DeviceType::L2G: { state = "L2G";                 break; }
+                case DeviceType::WZS: { state = "WZS";                 break; }
+                default:              { state = std::to_string(value); break; }
+            }
+
+            m_sensor_device_type.set_state(state);
+        }
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_firmware_version.set_state(response, start + 1, end);  // skip leading space
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+
+        if (m_sensor_bivalence_level.has_sensor())
+        {
+            std::string state = "";
+            int32_t value = get_number(response, start, end);
+
+            switch (static_cast<BivalenceLevel>(value))
+            {
+                case BivalenceLevel::SINGLE_COMPRESSOR: { state = "single_compressor";   break; }
+                case BivalenceLevel::DUAL_COMPRESSOR:   { state = "dual_compressor";     break; }
+                case BivalenceLevel::ADDITIONAL_HEATER: { state = "additional_heater";   break; }
+                default:                                { state = std::to_string(value); break; }
+            }
+
+            m_sensor_bivalence_level.set_state(state);
+        }
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+
+        if (m_sensor_operational_state.has_sensor())
+        {
+            std::string state = "";
+            int32_t value = get_number(response, start, end);
+
+            switch (static_cast<OperationalState>(value))
+            {
+                case OperationalState::HEAT:          { state = "heat";                break; }
+                case OperationalState::HOT_WATER:     { state = "hot_water";           break; }
+                case OperationalState::SWIMMING_POOL: { state = "swimming_pool";       break; }
+                case OperationalState::PROVIDER_LOCK: { state = "provider_lock";       break; }
+                case OperationalState::DEFROST:       { state = "defrost";             break; }
+                case OperationalState::STANDBY:       { state = "standby";             break; }
+                default:                              { state = std::to_string(value); break; }
+            }
+
+            m_sensor_operational_state.set_state(state);
+        }
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_heating_curves(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_hc_return_offset.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_hc_endpoint.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_hc_parallel_shift.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_hc_night_setback.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_hc_constant_return.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_mc1_endpoint.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_mc1_parallel_shift.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_mc1_night_setback.set_state(response, start, end);
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_heating_curve_mc1_constant_flow.set_state(response, start, end);
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_heating_mode(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+
+        if (m_sensor_heating_mode.has_sensor())
+        {
+            std::string state = "";
+            int32_t value = get_number(response, start, end);
+
+            switch (static_cast<OperationalMode>(value))
+            {
+                case OperationalMode::AUTO:          { state = "auto";                break; }
+                case OperationalMode::SECOND_HEATER: { state = "second_heater";       break; }
+                case OperationalMode::PARTY:         { state = "party";               break; }
+                case OperationalMode::VACATION:      { state = "vacation";            break; }
+                case OperationalMode::OFF:           { state = "off";                 break; }
+                default:                             { state = std::to_string(value); break; }
+            }
+
+            m_sensor_heating_mode.set_state(state);
+        }
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_hot_water_config(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+        m_sensor_hot_water_set_temperature.set_state(response, start, end);
+
+        next_dataset();
+    }
+
+    void Luxtronik::parse_hot_water_mode(const std::string& response)
+    {
+        accept_response();
+
+        size_t start = INDEX_RESPONSE_START;
+        size_t end = response.find(DELIMITER, start);
+        // skip number of elements
+
+        start = end + 1;
+        end = response.find(DELIMITER, start);
+
+        if (m_sensor_hot_water_mode.has_sensor())
+        {
+            std::string state = "";
+            int32_t value = get_number(response, start, end);
+
+            switch (static_cast<OperationalMode>(value))
+            {
+                case OperationalMode::AUTO:          { state = "auto";                break; }
+                case OperationalMode::SECOND_HEATER: { state = "second_heater";       break; }
+                case OperationalMode::PARTY:         { state = "party";               break; }
+                case OperationalMode::VACATION:      { state = "vacation";            break; }
+                case OperationalMode::OFF:           { state = "off";                 break; }
+                default:                             { state = std::to_string(value); break; }
+            }
+
+            m_sensor_hot_water_mode.set_state(state);
+        }
+
+        next_dataset();
+    }
+
 
     void Luxtronik::parse_slot(const std::string& slot, StringSensor& sensor_code, StringSensor& sensor_time)
     {
@@ -1070,6 +1152,45 @@ namespace esphome::luxtronik_v1
         else
         {
             ESP_LOGW(TAG, "Invalid value for hot water set temperature:  VAL %.1f °C", value);
+        }
+    }
+
+    void Luxtronik::set_heating_curves(HeatingCurves& value)
+    {
+        if (!value.hc_return_offset_avail)   { value.hc_return_offset   = m_sensor_heating_curve_hc_return_offset.get_state();   }
+        if (!value.hc_endpoint_avail)        { value.hc_endpoint        = m_sensor_heating_curve_hc_endpoint.get_state();        }
+        if (!value.hc_parallel_shift_avail)  { value.hc_parallel_shift  = m_sensor_heating_curve_hc_parallel_shift.get_state();  }
+        if (!value.hc_night_setback_avail)   { value.hc_night_setback   = m_sensor_heating_curve_hc_night_setback.get_state();   }
+        if (!value.hc_const_return_avail)    { value.hc_const_return    = m_sensor_heating_curve_hc_constant_return.get_state(); }
+        if (!value.mc1_endpoint_avail)       { value.mc1_endpoint       = m_sensor_heating_curve_mc1_endpoint.get_state();       }
+        if (!value.mc1_parallel_shift_avail) { value.mc1_parallel_shift = m_sensor_heating_curve_mc1_parallel_shift.get_state(); }
+        if (!value.mc1_night_setback_avail)  { value.mc1_night_setback  = m_sensor_heating_curve_mc1_night_setback.get_state();  }
+        if (!value.mc1_const_flow_avail)     { value.mc1_const_flow     = m_sensor_heating_curve_mc1_constant_flow.get_state();  }
+
+        ESP_LOGD(
+            TAG,
+            "Queuing requests for setting heating curves:  HOF %.1f °C  HEP %.1f °C  HPS %.1f °C  HNS %.1f °C  HCR %.1f °C  MEP %.1f °C  MPS %.1f °C  MNS %.1f °C  MCF %.1f °C",
+            value.hc_return_offset,
+            value.hc_endpoint, value.hc_parallel_shift, value.hc_night_setback, value.hc_const_return,
+            value.mc1_endpoint, value.mc1_parallel_shift, value.mc1_night_setback, value.mc1_const_flow);
+
+        m_request_queue.push_back(TYPE_HEATING_CURVES_CONFIG);
+        m_request_queue.push_back(
+                            std::string(TYPE_HEATING_CURVES_CONFIG) + ";9;" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.hc_return_offset * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.hc_endpoint * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.hc_parallel_shift * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.hc_night_setback * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.hc_const_return * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.mc1_endpoint * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.mc1_parallel_shift * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.mc1_night_setback * 10))) + ";" +
+                            std::to_string(static_cast<int32_t>(std::floor(value.mc1_const_flow * 10))));
+        m_request_queue.push_back(TYPE_STORE_CONFIG);
+
+        if (!m_timer.is_running())
+        {
+            request_data();
         }
     }
 

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -80,12 +80,12 @@ namespace esphome::luxtronik_v1
         void set_sensor_mixed_circuit_1_temperature(sensor::Sensor* sensor)      { m_sensor_mixed_circuit_1_temperature.set_sensor(sensor);      }
         void set_sensor_mixed_circuit_1_set_temperature(sensor::Sensor* sensor)  { m_sensor_mixed_circuit_1_set_temperature.set_sensor(sensor);  }
         void set_sensor_remote_adjuster_temperature(sensor::Sensor* sensor)      { m_sensor_remote_adjuster_temperature.set_sensor(sensor);      }
-        void set_sensor_heating_curve_offset(sensor::Sensor* sensor)             { m_sensor_heating_curve_offset.set_sensor(sensor);             }
-        void set_sensor_heating_curve_endpoint(sensor::Sensor* sensor)           { m_sensor_heating_curve_endpoint.set_sensor(sensor);           }
-        void set_sensor_heating_curve_parallel_shift(sensor::Sensor* sensor)     { m_sensor_heating_curve_parallel_shift.set_sensor(sensor);     }
-        void set_sensor_heating_curve_night_setback(sensor::Sensor* sensor)      { m_sensor_heating_curve_night_setback.set_sensor(sensor);      }
-        void set_sensor_heating_curve_constant_return(sensor::Sensor* sensor)    { m_sensor_heating_curve_constant_return.set_sensor(sensor);    }
-        void set_sensor_heating_curve_mc1_end_point(sensor::Sensor* sensor)      { m_sensor_heating_curve_mc1_end_point.set_sensor(sensor);      }
+        void set_sensor_heating_curve_hc_return_offset(sensor::Sensor* sensor)   { m_sensor_heating_curve_hc_return_offset.set_sensor(sensor);   }
+        void set_sensor_heating_curve_hc_endpoint(sensor::Sensor* sensor)        { m_sensor_heating_curve_hc_endpoint.set_sensor(sensor);        }
+        void set_sensor_heating_curve_hc_parallel_shift(sensor::Sensor* sensor)  { m_sensor_heating_curve_hc_parallel_shift.set_sensor(sensor);  }
+        void set_sensor_heating_curve_hc_night_setback(sensor::Sensor* sensor)   { m_sensor_heating_curve_hc_night_setback.set_sensor(sensor);   }
+        void set_sensor_heating_curve_hc_constant_return(sensor::Sensor* sensor) { m_sensor_heating_curve_hc_constant_return.set_sensor(sensor); }
+        void set_sensor_heating_curve_mc1_endpoint(sensor::Sensor* sensor)       { m_sensor_heating_curve_mc1_endpoint.set_sensor(sensor);       }
         void set_sensor_heating_curve_mc1_parallel_shift(sensor::Sensor* sensor) { m_sensor_heating_curve_mc1_parallel_shift.set_sensor(sensor); }
         void set_sensor_heating_curve_mc1_night_setback(sensor::Sensor* sensor)  { m_sensor_heating_curve_mc1_night_setback.set_sensor(sensor);  }
         void set_sensor_heating_curve_mc1_constant_flow(sensor::Sensor* sensor)  { m_sensor_heating_curve_mc1_constant_flow.set_sensor(sensor);  }
@@ -215,12 +215,12 @@ namespace esphome::luxtronik_v1
         StringSensor m_sensor_operational_state;  // 1700:5 - Betriebszustand
 
         // heat curve
-        TemperatureSensor m_sensor_heating_curve_offset;              // 3400:2  - Abweichung Heizkurve
-        TemperatureSensor m_sensor_heating_curve_endpoint;            // 3400:3  - Heizkurve Endpunt
-        TemperatureSensor m_sensor_heating_curve_parallel_shift;      // 3400:4  - Heizkurve Parallelverschiebung
-        TemperatureSensor m_sensor_heating_curve_night_setback;       // 3400:5  - Heizkurve Nachtabsenkung
-        TemperatureSensor m_sensor_heating_curve_constant_return;     // 3400:6  - Heizkurve Festwert Rücklauf
-        TemperatureSensor m_sensor_heating_curve_mc1_end_point;       // 3400:7  - Heizkurve MK1 Endpunt
+        TemperatureSensor m_sensor_heating_curve_hc_return_offset;    // 3400:2  - Heizkurve HK Abweichung Rücklauf
+        TemperatureSensor m_sensor_heating_curve_hc_endpoint;         // 3400:3  - Heizkurve HK Endpunkt
+        TemperatureSensor m_sensor_heating_curve_hc_parallel_shift;   // 3400:4  - Heizkurve HK Parallelverschiebung
+        TemperatureSensor m_sensor_heating_curve_hc_night_setback;    // 3400:5  - Heizkurve HK Nachtabsenkung
+        TemperatureSensor m_sensor_heating_curve_hc_constant_return;  // 3400:6  - Heizkurve HK Festwert Rücklauf
+        TemperatureSensor m_sensor_heating_curve_mc1_endpoint;        // 3400:7  - Heizkurve MK1 Endpunkt
         TemperatureSensor m_sensor_heating_curve_mc1_parallel_shift;  // 3400:8  - Heizkurve MK1 Parallelverschiebung
         TemperatureSensor m_sensor_heating_curve_mc1_night_setback;   // 3400:9  - Heizkurve MK1 Nachtabsenkung
         TemperatureSensor m_sensor_heating_curve_mc1_constant_flow;   // 3400:10 - Heizkurve MK1 Festwert Vorlauf

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -53,6 +53,28 @@ namespace esphome::luxtronik_v1
     class Luxtronik : public PollingComponent
     {
     public:
+        struct HeatingCurves
+        {
+            bool hc_return_offset_avail;
+            float hc_return_offset;
+            bool hc_endpoint_avail;
+            float hc_endpoint;
+            bool hc_parallel_shift_avail;
+            float hc_parallel_shift;
+            bool hc_night_setback_avail;
+            float hc_night_setback;
+            bool hc_const_return_avail;
+            float hc_const_return;
+            bool mc1_endpoint_avail;
+            float mc1_endpoint;
+            bool mc1_parallel_shift_avail;
+            float mc1_parallel_shift;
+            bool mc1_night_setback_avail;
+            float mc1_night_setback;
+            bool mc1_const_flow_avail;
+            float mc1_const_flow;
+        };
+
         Luxtronik(
             uart::UARTComponent* uart,
             uint16_t request_delay,
@@ -66,6 +88,7 @@ namespace esphome::luxtronik_v1
 
         void add_dataset(const char* code);
         void set_hot_water_set_temperature(float value);
+        void set_heating_curves(HeatingCurves& value);
 
 #ifdef USE_SENSOR
         void set_sensor_flow_temperature(sensor::Sensor* sensor)                 { m_sensor_flow_temperature.set_sensor(sensor);                 }
@@ -155,11 +178,22 @@ namespace esphome::luxtronik_v1
         void request_data();
         void send_request(const std::string& request);
         void parse_response(const std::string& response);
+        void parse_temperatures(const std::string& response);
+        void parse_inputs(const std::string& response);
+        void parse_outputs(const std::string& response);
+        void parse_operating_hours(const std::string& response);
+        void parse_errors(const std::string& response);
+        void parse_deactivations(const std::string& response);
+        void parse_information(const std::string& response);
+        void parse_heating_curves(const std::string& response);
+        void parse_heating_mode(const std::string& response);
+        void parse_hot_water_config(const std::string& response);
+        void parse_hot_water_mode(const std::string& response);
         void handle_timeout();
         void clear_uart_buffer();
         void parse_slot(const std::string& slot, StringSensor& sensor_code, StringSensor& sensor_time);
 
-        void ack_response()
+        void accept_response()
         {
             m_timer.cancel();
             m_retry_count = 0;

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -278,6 +278,7 @@ namespace esphome::luxtronik_v1
         bool m_lost_response;
         bool m_response_ready;
         bool m_slot_block;
+        uint8_t m_config_response_state;
         uint16_t m_retry_count;
         std::string m_store_config_ack;
         std::vector<const char*> m_dataset_list;

--- a/components/luxtronik_v1/luxtronik_sensor.h
+++ b/components/luxtronik_v1/luxtronik_sensor.h
@@ -93,6 +93,15 @@ namespace esphome::luxtronik_v1
 #endif
         }
 
+        float get_state() const
+        {
+#ifdef USE_SENSOR
+            return (m_sensor != nullptr) ? m_sensor->state : 0.0;
+#else
+            return 0.0;
+#endif
+        }
+
 #ifdef USE_SENSOR
         void set_sensor(sensor::Sensor* sensor) { m_sensor = sensor; }
         sensor::Sensor* get_sensor() { return m_sensor; }

--- a/components/luxtronik_v1/sensor.py
+++ b/components/luxtronik_v1/sensor.py
@@ -52,12 +52,12 @@ CONF_HEAT_SOURCE_OUTPUT_TEMPERATURE   = "heat_source_output_temperature"
 CONF_MIXED_CIRCUIT_1_TEMPERATURE      = "mixed_circuit_1_temperature"
 CONF_MIXED_CIRCUIT_1_SET_TEMPERATURE  = "mixed_circuit_1_set_temperature"
 CONF_REMOTE_ADJUSTER_TEMPERATURE      = "remote_adjuster_temperature"
-CONF_HEATING_CURVE_OFFSET             = "heating_curve_offset"
-CONF_HEATING_CURVE_ENDPOINT           = "heating_curve_endpoint"
-CONF_HEATING_CURVE_PARALLEL_SHIFT     = "heating_curve_parallel_shift"
-CONF_HEATING_CURVE_NIGHT_SETBACK      = "heating_curve_night_setback"
-CONF_HEATING_CURVE_CONSTANT_RETURN    = "heating_curve_constant_return"
-CONF_HEATING_CURVE_MC1_END_POINT      = "heating_curve_mc1_end_point"
+CONF_HEATING_CURVE_HC_RETURN_OFFSET   = "heating_curve_hc_return_offset"
+CONF_HEATING_CURVE_HC_ENDPOINT        = "heating_curve_hc_endpoint"
+CONF_HEATING_CURVE_HC_PARALLEL_SHIFT  = "heating_curve_hc_parallel_shift"
+CONF_HEATING_CURVE_HC_NIGHT_SETBACK   = "heating_curve_hc_night_setback"
+CONF_HEATING_CURVE_HC_CONSTANT_RETURN = "heating_curve_hc_constant_return"
+CONF_HEATING_CURVE_MC1_ENDPOINT       = "heating_curve_mc1_endpoint"
 CONF_HEATING_CURVE_MC1_PARALLEL_SHIFT = "heating_curve_mc1_parallel_shift"
 CONF_HEATING_CURVE_MC1_NIGHT_SETBACK  = "heating_curve_mc1_night_setback"
 CONF_HEATING_CURVE_MC1_CONSTANT_FLOW  = "heating_curve_mc1_constant_flow"
@@ -147,42 +147,42 @@ CONFIG_SCHEMA = cv.Schema(
         unit_of_measurement = UNIT_CELSIUS,
         accuracy_decimals = 1
     ),
-    cv.Optional(CONF_HEATING_CURVE_OFFSET): sensor.sensor_schema(
+    cv.Optional(CONF_HEATING_CURVE_HC_RETURN_OFFSET): sensor.sensor_schema(
         device_class = DEVICE_CLASS_TEMPERATURE,
         state_class = STATE_CLASS_MEASUREMENT,
         unit_of_measurement = UNIT_CELSIUS,
         accuracy_decimals = 1,
         icon = "mdi:plus-minus-variant"
     ),
-    cv.Optional(CONF_HEATING_CURVE_ENDPOINT): sensor.sensor_schema(
+    cv.Optional(CONF_HEATING_CURVE_HC_ENDPOINT): sensor.sensor_schema(
         device_class = DEVICE_CLASS_TEMPERATURE,
         state_class = STATE_CLASS_MEASUREMENT,
         unit_of_measurement = UNIT_CELSIUS,
         accuracy_decimals = 1,
         icon = "mdi:arrow-collapse-right"
     ),
-    cv.Optional(CONF_HEATING_CURVE_PARALLEL_SHIFT): sensor.sensor_schema(
+    cv.Optional(CONF_HEATING_CURVE_HC_PARALLEL_SHIFT): sensor.sensor_schema(
         device_class = DEVICE_CLASS_TEMPERATURE,
         state_class = STATE_CLASS_MEASUREMENT,
         unit_of_measurement = UNIT_CELSIUS,
         accuracy_decimals = 1,
         icon = "mdi:arrow-expand"
     ),
-    cv.Optional(CONF_HEATING_CURVE_NIGHT_SETBACK): sensor.sensor_schema(
+    cv.Optional(CONF_HEATING_CURVE_HC_NIGHT_SETBACK): sensor.sensor_schema(
         device_class = DEVICE_CLASS_TEMPERATURE,
         state_class = STATE_CLASS_MEASUREMENT,
         unit_of_measurement = UNIT_CELSIUS,
         accuracy_decimals = 1,
         icon = "mdi:moon-waning-crescent"
     ),
-    cv.Optional(CONF_HEATING_CURVE_CONSTANT_RETURN): sensor.sensor_schema(
+    cv.Optional(CONF_HEATING_CURVE_HC_CONSTANT_RETURN): sensor.sensor_schema(
         device_class = DEVICE_CLASS_TEMPERATURE,
         state_class = STATE_CLASS_MEASUREMENT,
         unit_of_measurement = UNIT_CELSIUS,
         accuracy_decimals = 1,
         icon = "mdi:format-vertical-align-center"
     ),
-    cv.Optional(CONF_HEATING_CURVE_MC1_END_POINT): sensor.sensor_schema(
+    cv.Optional(CONF_HEATING_CURVE_MC1_ENDPOINT): sensor.sensor_schema(
         device_class = DEVICE_CLASS_TEMPERATURE,
         state_class = STATE_CLASS_MEASUREMENT,
         unit_of_measurement = UNIT_CELSIUS,

--- a/components/luxtronik_v1/simple_queue.h
+++ b/components/luxtronik_v1/simple_queue.h
@@ -113,7 +113,7 @@ namespace esphome::luxtronik_v1
             ++m_size;
         }
 
-        const void pop_front()
+        void pop_front()
         {
             if (m_head != nullptr)
             {

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -93,17 +93,17 @@ sensor:
       name: Soll-Temperatur Vorlauf Mischkreis 1
     remote_adjuster_temperature:
       name: Temperatur Raumfernversteller
-    heating_curve_offset:
-      name: Abweichung Heizkurve
-    heating_curve_endpoint:
-      name: Heizkurve Endpunkt
-    heating_curve_parallel_shift:
-      name: Heizkurve Parallelverschiebung
-    heating_curve_night_setback:
-      name: Heizkurve Nachtabsenkung
-    heating_curve_constant_return:
-      name: Heizkurve Festwert Rücklauf
-    heating_curve_mc1_end_point:
+    heating_curve_hc_return_offset:
+      name: Heizkurve Heizkreis Abweichung Rücklauf
+    heating_curve_hc_endpoint:
+      name: Heizkurve Heizkreis Endpunkt
+    heating_curve_hc_parallel_shift:
+      name: Heizkurve Heizkreis Parallelverschiebung
+    heating_curve_hc_night_setback:
+      name: Heizkurve Heizkreis Nachtabsenkung
+    heating_curve_hc_constant_return:
+      name: Heizkurve Heizkreis Festwert Rücklauf
+    heating_curve_mc1_endpoint:
       name: Heizkurve Mischkreis 1 Endpunkt
     heating_curve_mc1_parallel_shift:
       name: Heizkurve Mischkreis 1 Parallelverschiebung

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -305,6 +305,132 @@ number:
     min_value: 20.0
     max_value: 65.0
     step: 0.5
+  # number input for setting return temperature offset from heat curcuit heating curve
+  - platform: template
+    id: heating_curve_hc_return_offset_value
+    name: Abweichung Rücklauf von Heizkurve
+    icon: mdi:plus-minus-variant
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 0.0
+    min_value: -5.0
+    max_value: 5.0
+    step: 0.5
+  # number input for setting heat curcuit heating curve endpoint
+  - platform: template
+    id: heating_curve_hc_endpoint_value
+    name: Heizkurve Endpunkt
+    icon: mdi:arrow-collapse-right
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 35.0
+    min_value: 20.0
+    max_value: 50.0
+    step: 0.5
+  # number input for setting heat curcuit heating curve parallel shift
+  - platform: template
+    id: heating_curve_hc_parallel_shift_value
+    name: Heizkurve Parallelverschiebung
+    icon: mdi:arrow-expand
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 20.0
+    min_value: 0.0
+    max_value: 40.0
+    step: 0.5
+  # number input for setting heat curcuit heating curve night setback
+  - platform: template
+    id: heating_curve_hc_night_setback_value
+    name: Heizkurve Nachtabsenkung
+    icon: mdi:moon-waning-crescent
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 0.0
+    min_value: -10.0
+    max_value: 0.0
+    step: 0.5
+  # number input for setting heat curcuit constant return temperature
+  - platform: template
+    id: heating_curve_hc_constant_return_value
+    name: Heizkurve Festwert Rücklauf
+    icon: mdi:format-vertical-align-center
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 35.0
+    min_value: 0.0
+    max_value: 50.0
+    step: 0.5
+  # number input for setting mixed curcuit 1 endpoint
+  - platform: template
+    id: heating_curve_mc1_endpoint_value
+    name: Heizkurve Mischkreis 1 Endpunkt
+    icon: mdi:arrow-collapse-right
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 35.0
+    min_value: 20.0
+    max_value: 50.0
+    step: 0.5
+  # number input for setting mixed curcuit 1 parallel shift
+  - platform: template
+    id: heating_curve_mc1_parallel_shift_value
+    name: Heizkurve Mischkreis 1 Parallelverschiebung
+    icon: mdi:arrow-expand
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 20.0
+    min_value: 0.0
+    max_value: 40.0
+    step: 0.5
+  # number input for setting mixed curcuit 1 night setback
+  - platform: template
+    id: heating_curve_mc1_night_setback_value
+    name: Heizkurve Mischkreis 1 Nachtabsenkung
+    icon: mdi:moon-waning-crescent
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 0.0
+    min_value: -10.0
+    max_value: 0.0
+    step: 0.5
+  # number input for setting mixed curcuit 1 constant flow temperature
+  - platform: template
+    id: heating_curve_mc1_constant_flow_value
+    name: Heizkurve Mischkreis 1 Festwert Vorlauf
+    icon: mdi:format-vertical-align-center
+    unit_of_measurement: °C
+    device_class: temperature
+    entity_category: config
+    mode: slider
+    optimistic: true
+    initial_value: 35.0
+    min_value: 0.0
+    max_value: 50.0
+    step: 0.5
 
 button:
   # button for sending hot water set temperature to Luxtronik heating control unit
@@ -316,3 +442,20 @@ button:
       - luxtronik_v1.set_hot_water_set_temperature:
           id: luxtronik_heat_pump
           value: !lambda "return id(hot_water_set_temperature_value).state;"
+  # button for sending heating curves to Luxtronik heating control unit
+  - platform: template
+    name: Heizkurve setzen
+    icon: mdi:download
+    entity_category: config
+    on_press:
+      - luxtronik_v1.set_heating_curves:
+          id: luxtronik_heat_pump
+          hc_return_offset: !lambda "return id(heating_curve_hc_return_offset_value).state;"
+          hc_endpoint: !lambda "return id(heating_curve_hc_endpoint_value).state;"
+          hc_parallel_shift: !lambda "return id(heating_curve_hc_parallel_shift_value).state;"
+          hc_night_setback: !lambda "return id(heating_curve_hc_night_setback_value).state;"
+          hc_const_return: !lambda "return id(heating_curve_hc_constant_return_value).state;"
+          mc1_endpoint: !lambda "return id(heating_curve_mc1_endpoint_value).state;"
+          mc1_parallel_shift: !lambda "return id(heating_curve_mc1_parallel_shift_value).state;"
+          mc1_night_setback: !lambda "return id(heating_curve_mc1_night_setback_value).state;"
+          mc1_const_flow: !lambda "return id(heating_curve_mc1_constant_flow_value).state;"


### PR DESCRIPTION
Adds the possibility to change the heating curves configured in the Luxtronik heating control unit. For this purpose, the new action `set_heating_curves` has been added. It can be called either from a Home Assistant automation or from some UI elements like number inputs in combination with a button. It is possible to set all aspects of the heating curves at once or only parts of them.

Resolves #26