### PR TITLE
Possibility to set the hot water mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,29 @@ Folgende Betriebsarten werden unterstützt:
 
 Anstelle eines festen Modus kann auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Modus zurückgibt.
 
+#### Betriebsart für die Brauchwarmwasserzubereitung setzen
+| Aktion | Beschreibung |
+| ------ | ------------ |
+| `luxtronik_v1.set_hot_water_mode` | Setzt die Betriebsart für die Brauchwarmwasserzubereitung auf den angegebenen Modus |
+
+##### Parameter
+| Parameter | Typ | Bereich | Benötigt | Beschreibung |
+| --------- | --- | ------- | -------- | ------------ |
+| `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | - | ja | ID der [Luxtronik-Komponente](#luxtronik-komponente) |
+| `mode` | Zahl | `0`, `1`, `2`, `3`, `4` | ja | Betriebsart für die Brauchwarmwasserzubereitung |
+
+Folgende Betriebsarten werden unterstützt:
+
+| Betriebsart | Beschreibung |
+| ----------- | ------------ |
+| `0` | Automatik |
+| `1` | Zweiter Wärmeerzeuger |
+| `2` | Party |
+| `3` | Ferien |
+| `4` | Aus |
+
+Anstelle eines festen Modus kann auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Modus zurückgibt.
+
 #### Soll-Temperatur für Brauchwarmwasser setzen
 | Aktion | Beschreibung |
 | ------ | ------------ |
@@ -948,7 +971,7 @@ The Luxtronik component provides various actions for programming the Luxtronik h
 | `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | - | yes | ID of the [Luxtronik component](#luxtronik-component) |
 | `mode` | Number | `0`, `1`, `2`, `3`, `4` | yes | Heating mode to be activated |
 
-Folgende Betriebsarten werden unterstützt:
+The following modes are supported:
 
 | Mode | Description |
 | ---- | ----------- |
@@ -958,7 +981,30 @@ Folgende Betriebsarten werden unterstützt:
 | `3` | Vacation |
 | `4` | Off |
 
-Instead of a fixed numeric value, it is also possible to specify a lambda expression that returns the value to be passed to the action.
+Instead of a fixed numeric mode, it is also possible to specify a lambda expression that returns the mode to be passed to the action.
+
+#### Set Hot Water Mode
+| Action | Description |
+| ------ | ----------- |
+| `luxtronik_v1.set_hot_water_mode` | Sets the hot water mode to the given mode |
+
+##### Parameters
+| Parameter | Type | Range | Mandatory | Description |
+| --------- | ---- | ----- | --------- | ----------- |
+| `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | - | yes | ID of the [Luxtronik component](#luxtronik-component) |
+| `mode` | Number | `0`, `1`, `2`, `3`, `4` | yes | Hot water mode to be activated |
+
+The following modes are supported:
+
+| Mode | Description |
+| ---- | ----------- |
+| `0` | Automatic |
+| `1` | Second Heater |
+| `2` | Party |
+| `3` | Vacation |
+| `4` | Off |
+
+Instead of a fixed numeric mode, it is also possible to specify a lambda expression that returns the mode to be passed to the action.
 
 #### Set Hot Water Set Temperature
 | Action | Description |

--- a/components/luxtronik_v1/automation.h
+++ b/components/luxtronik_v1/automation.h
@@ -33,28 +33,30 @@
 
 namespace esphome::luxtronik_v1
 {
-    template<typename... Ts> class SetHeatingModeAction : public Action<Ts...>
+    template<typename... Ts> class SetOperationalModeAction : public Action<Ts...>
     {
     public:
-        SetHeatingModeAction(Luxtronik *luxtronik)
+        SetOperationalModeAction(Luxtronik *luxtronik, uint8_t mode_type)
             : m_luxtronik(luxtronik)
-            , m_heating_mode_value()
+            , m_mode_type(static_cast<Luxtronik::OperationalModeType>(mode_type))
+            , m_operational_mode_value()
         {
         }
 
         void play(Ts... x) override
         {
-            m_luxtronik->set_heating_mode(m_heating_mode_value.value(x...));
+            m_luxtronik->set_operational_mode(m_mode_type, m_operational_mode_value.value(x...));
         }
 
-        template<typename V> void set_heating_mode_value(V value)
+        template<typename V> void set_operational_mode_value(V value)
         {
-            m_heating_mode_value = value;
+            m_operational_mode_value = value;
         }
 
     protected:
         Luxtronik *m_luxtronik;
-        TemplatableValue<uint8_t, Ts...> m_heating_mode_value;
+        Luxtronik::OperationalModeType m_mode_type;
+        TemplatableValue<uint8_t, Ts...> m_operational_mode_value;
     };
 
     template<typename... Ts> class SetHotWaterSetTemperatureAction : public Action<Ts...>

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -53,6 +53,12 @@ namespace esphome::luxtronik_v1
     class Luxtronik : public PollingComponent
     {
     public:
+        enum OperationalModeType
+        {
+            HEATING   = 0,
+            HOT_WATER = 1
+        };
+
         struct HeatingCurves
         {
             bool hc_return_offset_avail;
@@ -87,7 +93,7 @@ namespace esphome::luxtronik_v1
         void dump_config() override;
 
         void add_dataset(const char* code);
-        void set_heating_mode(uint8_t value);
+        void set_operational_mode(OperationalModeType type, uint8_t value);
         void set_hot_water_set_temperature(float value);
         void set_heating_curves(HeatingCurves& value);
 

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -218,6 +218,7 @@ text_sensor:
           - vacation -> Ferien
           - off -> Aus
     hot_water_mode:
+      id: current_hot_water_mode
       name: Betriebsart Brauchwarmwasser
       # alternatively, the filters can be removed and translation can be done in Home Assistant
       filters:
@@ -462,6 +463,27 @@ select:
             auto idx = id(target_heating_mode).index_of(x);
             return idx.has_value() ? idx.value() : 255;
       - lambda: "id(target_heating_mode).publish_state(x);"
+  # selection for heating mode
+  - platform: template
+    id: target_hot_water_mode
+    name: Betriebsart Brauchwarmwasser
+    icon: mdi:water-boiler
+    entity_category: config
+    options:
+      - Automatik
+      - Zweiter Wärmeerzeuger
+      - Party
+      - Ferien
+      - Aus
+    lambda: !lambda |-
+      return id(current_hot_water_mode).state;
+    set_action:
+      - luxtronik_v1.set_hot_water_mode:
+          id: lwc_100
+          mode: !lambda |-
+            auto idx = id(target_hot_water_mode).index_of(x);
+            return idx.has_value() ? idx.value() : 255;
+      - lambda: "id(target_hot_water_mode).publish_state(x);"
 
 button:
   # button for sending heating curves to Luxtronik heating control unit

--- a/test/luxtronik_simu.py
+++ b/test/luxtronik_simu.py
@@ -27,6 +27,7 @@
 import serial
 
 heating_mode = '4'
+hot_water_mode = '0'
 hot_water_set_temp = '460'
 heating_curve = '0;320;220;0;350;350;200;0;350'
 
@@ -79,14 +80,11 @@ def send_information():
 def send_heating_curve(cmd):
     respond(f'{cmd};9;{heating_curve}')
 
-def send_heating_mode(cmd):
-    respond(f'{cmd};1;{heating_mode}')
+def send_operational_mode(cmd, mode):
+    respond(f'{cmd};1;{mode}')
 
 def send_hot_water_set_temp():
     respond(f'3501;1;{hot_water_set_temp}')
-
-def send_hot_water_mode():
-    respond('3505;1;0')
 
 def send_store_config_ack():
     respond('993')
@@ -94,6 +92,11 @@ def send_store_config_ack():
     respond('999')
 
 def parse_command(cmd):
+    global heating_curve
+    global heating_mode
+    global hot_water_mode
+    global hot_water_set_temp
+
     try:
         cmd_str = cmd.decode('ascii')
         print('Parsing command: ' + cmd_str)
@@ -131,27 +134,30 @@ def parse_command(cmd):
             if len(cmd_str) == 4:
                 send_heating_curve('3401')
             elif len(cmd_str) > 7:
-                global heating_curve
                 heating_curve = cmd_str[7:]
                 send_heating_curve('3401')
         elif cmd_str == '3405':
-            send_heating_mode('3405')
+            send_operational_mode('3405', heating_mode)
         elif cmd_str.startswith('3406'):
             if len(cmd_str) == 4:
-                send_heating_mode('3406')
+                send_operational_mode('3406', heating_mode)
             elif len(cmd_str) > 7:
-                global heating_mode
                 heating_mode = cmd_str[7:]
-                send_heating_mode('3406')
+                send_operational_mode('3406', heating_mode)
         elif cmd_str.startswith('3501'):
             if len(cmd_str) == 4:
                 send_hot_water_set_temp()
             elif len(cmd_str) > 7:
-                global hot_water_set_temp
                 hot_water_set_temp = cmd_str[7:]
                 send_hot_water_set_temp()
         elif cmd_str == '3505':
-            send_hot_water_mode()
+            send_operational_mode('3505', hot_water_mode)
+        elif cmd_str.startswith('3506'):
+            if len(cmd_str) == 4:
+                send_operational_mode('3506', hot_water_mode)
+            elif len(cmd_str) > 7:
+                hot_water_mode = cmd_str[7:]
+                send_operational_mode('3506', hot_water_mode)
         elif cmd_str == '999':
             send_store_config_ack()
     except UnicodeDecodeError:


### PR DESCRIPTION
Adds the possibility to change the hot water mode configured in the Luxtronik heating control unit. For this purpose, the new action `set_hot_water_mode` has been added. It can be called either from a Home Assistant automation or from some UI element like a select component.

Resolves #29