### PR TITLE
Possibility to set the hot water week off-times

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,26 @@ Anstelle eines festen Modus kann auch ein Lambda-Ausdruck verwendet werden, der 
 
 Anstelle eines festen Zahlenwerts kann auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Wert zurückgibt.
 
+#### Tägliche Brauchwarmwasser-Sperrzeiten setzen
+| Aktion | Beschreibung |
+| ------ | ------------ |
+| `luxtronik_v1.set_hot_water_off_times_week` | Setzt die täglichen Sperrzeiten für die Warmwasserzubereitung |
+
+##### Parameter
+| Parameter | Typ | Bereich | Benötigt | Beschreibung |
+| --------- | --- | ------- | -------- | ------------ |
+| `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | - | ja | ID der [Luxtronik-Komponente](#luxtronik-komponente) |
+| `start_1_hour` | Zahl | 0&nbsp;...&nbsp;23 | ja | Stundenwert des Beginns der ersten Sperrzeit |
+| `start_1_minute` | Zahl | 0&nbsp;...&nbsp;59 | ja | Minutenwert des Beginns der ersten Sperrzeit |
+| `end_1_hour` | Zahl | 0&nbsp;...&nbsp;23 | ja | Stundenwert des Endes der ersten Sperrzeit |
+| `end_1_minute` | Zahl | 0&nbsp;...&nbsp;59 | ja | Minutenwert des Endes der ersten Sperrzeit |
+| `start_2_hour` | Zahl | 0&nbsp;...&nbsp;23 | ja |  Stundenwert des Beginns der zweiten Sperrzeit |
+| `start_2_minute` | Zahl | 0&nbsp;...&nbsp;59 | ja | Minutenwert des Beginns der zweiten Sperrzeit |
+| `end_2_hour` | Zahl | 0&nbsp;...&nbsp;23 | ja | Stundenwert des Endes der zweiten Sperrzeit |
+| `end_2_minute` | Zahl | 0&nbsp;...&nbsp;59 | ja | Minutenwert des Endes der zweiten Sperrzeit |
+
+Anstelle eines festen Zahlenwerts kann bei allen Parametern auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Wert zurückgibt.
+
 #### Heizkurven setzen
 | Aktion | Beschreibung |
 | ------ | ------------ |
@@ -511,14 +531,14 @@ Anstelle eines festen Zahlenwerts kann auch ein Lambda-Ausdruck verwendet werden
 | --------- | --- | ------- | -------- | ------------ |
 | `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | - | ja | ID der [Luxtronik-Komponente](#luxtronik-komponente) |
 | `hc_return_offset` | Zahl | -5.0&nbsp;...&nbsp;5.0 | nein | Abweichung der Rücklauf-Temperatur zu der Temperatur der Heizkreis-Heizkurve in °C |
-| `hc_endpoint` | Zahl | >=&nbsp;0.0 | nein |  Endpunkt der Heizkreis-Heizkurve in °C |
-| `hc_parallel_shift` | Zahl | >=&nbsp;0.0 | nein |  Parallelverschiebung der Heizkreis-Heizkurve in °C |
-| `hc_night_setback` | Zahl | <=&nbsp;0.0 | nein |  Nachtabsenkung der Heizkreis-Heizkurve in °C |
-| `hc_const_return` | Zahl | >=&nbsp;0.0 | nein |  Festwert für den Rücklauf des Heizkreises in °C |
-| `mc1_endpoint` | Zahl | >=&nbsp;0.0 | nein |  Endpunkt der Mischkreis-1-Heizkurve in °C |
-| `mc1_parallel_shift` | Zahl | >=&nbsp;0.0 | nein |  Parallelverschiebung der Mischkreis-1-Heizkurve in °C |
-| `mc1_night_setback` | Zahl | <=&nbsp;0.0 | nein |  Nachtabsenkung der Mischkreis-1-Heizkurve in °C |
-| `mc1_const_flow` | Zahl | >=&nbsp;0.0 | nein |  Festwert für den Vorlauf des Mischkreises 1 in °C |
+| `hc_endpoint` | Zahl | >=&nbsp;0.0 | nein | Endpunkt der Heizkreis-Heizkurve in °C |
+| `hc_parallel_shift` | Zahl | >=&nbsp;0.0 | nein | Parallelverschiebung der Heizkreis-Heizkurve in °C |
+| `hc_night_setback` | Zahl | <=&nbsp;0.0 | nein | Nachtabsenkung der Heizkreis-Heizkurve in °C |
+| `hc_const_return` | Zahl | >=&nbsp;0.0 | nein | Festwert für den Rücklauf des Heizkreises in °C |
+| `mc1_endpoint` | Zahl | >=&nbsp;0.0 | nein | Endpunkt der Mischkreis-1-Heizkurve in °C |
+| `mc1_parallel_shift` | Zahl | >=&nbsp;0.0 | nein | Parallelverschiebung der Mischkreis-1-Heizkurve in °C |
+| `mc1_night_setback` | Zahl | <=&nbsp;0.0 | nein | Nachtabsenkung der Mischkreis-1-Heizkurve in °C |
+| `mc1_const_flow` | Zahl | >=&nbsp;0.0 | nein | Festwert für den Vorlauf des Mischkreises 1 in °C |
 
 Anstelle eines festen Zahlenwerts kann bei allen Parametern auch ein Lambda-Ausdruck verwendet werden, der den zu übergebenden Wert zurückgibt.
 
@@ -1028,6 +1048,26 @@ Instead of a fixed numeric mode, it is also possible to specify a lambda express
 | `value` | Number | 30.0&nbsp;...&nbsp;65.0 | yes | Target value for the hot water set temperature in °C |
 
 Instead of a fixed numeric value, it is also possible to specify a lambda expression that returns the value to be passed to the action.
+
+#### Set Hot Water Week Off-Times
+| Action | Description |
+| ------ | ----------- |
+| `luxtronik_v1.set_hot_water_off_times_week` | Sets the daily off-times for hot water preparation |
+
+##### Parameter
+| Parameter | Type | Range | Mandatory | Description |
+| --------- | ---- | ----- | --------- | ----------- |
+| `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | - | yes | ID of the [Luxtronik component](#luxtronik-component) |
+| `start_1_hour` | Number | 0&nbsp;...&nbsp;23 | yes | Hour part of begin of first off-time |
+| `start_1_minute` | Number | 0&nbsp;...&nbsp;59 | yes | Minute part of begin of first off-time |
+| `end_1_hour` | Number | 0&nbsp;...&nbsp;23 | yes | Hour part of end of first off-time |
+| `end_1_minute` | Number | 0&nbsp;...&nbsp;59 | yes | Minute part of end of first off-time |
+| `start_2_hour` | Number | 0&nbsp;...&nbsp;23 | yes |  Hour part of begin of second off-time |
+| `start_2_minute` | Number | 0&nbsp;...&nbsp;59 | yes | Minute part of begin of second off-time |
+| `end_2_hour` | Number | 0&nbsp;...&nbsp;23 | yes | Hour part of end of second off-time |
+| `end_2_minute` | Number | 0&nbsp;...&nbsp;59 | yes | Minute part of end of second off-time |
+
+Instead of a fixed numerical value, lambda expressions can also be used for all parameters, which return the value to be passed.
 
 #### Set Heating Curves
 | Action | Description |

--- a/components/luxtronik_v1/__init__.py
+++ b/components/luxtronik_v1/__init__.py
@@ -53,6 +53,15 @@ CONF_MC1_PARALLEL_SHIFT = "mc1_parallel_shift"
 CONF_MC1_NIGHT_SETBACK  = "mc1_night_setback"
 CONF_MC1_CONST_FLOW     = "mc1_const_flow"
 
+CONF_START_1_HOUR   = "start_1_hour"
+CONF_START_1_MINUTE = "start_1_minute"
+CONF_END_1_HOUR     = "end_1_hour"
+CONF_END_1_MINUTE   = "end_1_minute"
+CONF_START_2_HOUR   = "start_2_hour"
+CONF_START_2_MINUTE = "start_2_minute"
+CONF_END_2_HOUR     = "end_2_hour"
+CONF_END_2_MINUTE   = "end_2_minute"
+
 TYPE_HEATING_MODE   = 0
 TYPE_HOT_WATER_MODE = 1
 
@@ -60,6 +69,7 @@ luxtronik_ns = cg.esphome_ns.namespace("luxtronik_v1")
 Luxtronik = luxtronik_ns.class_("Luxtronik", cg.PollingComponent)
 SetOperationalModeAction = luxtronik_ns.class_("SetOperationalModeAction", automation.Action)
 SetHotWaterSetTemperatureAction = luxtronik_ns.class_("SetHotWaterSetTemperatureAction", automation.Action)
+SetHotWaterOffTimesWeekAction = luxtronik_ns.class_("SetHotWaterOffTimesWeekAction", automation.Action)
 SetHeatingCurvesAction = luxtronik_ns.class_("SetHeatingCurvesAction", automation.Action)
 
 def unique_list(value):
@@ -145,6 +155,44 @@ async def set_hot_water_set_temperature_action_to_code(config, action_id, templa
     return act
 
 @automation.register_action(
+    "luxtronik_v1.set_hot_water_off_times_week",
+    SetHotWaterOffTimesWeekAction,
+    cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(Luxtronik),
+        cv.Required(CONF_START_1_HOUR): cv.templatable(cv.int_range(min = 0, max = 23)),
+        cv.Required(CONF_START_1_MINUTE): cv.templatable(cv.int_range(min = 0, max = 59)),
+        cv.Required(CONF_END_1_HOUR): cv.templatable(cv.int_range(min = 0, max = 23)),
+        cv.Required(CONF_END_1_MINUTE): cv.templatable(cv.int_range(min = 0, max = 59)),
+        cv.Required(CONF_START_2_HOUR): cv.templatable(cv.int_range(min = 0, max = 23)),
+        cv.Required(CONF_START_2_MINUTE): cv.templatable(cv.int_range(min = 0, max = 59)),
+        cv.Required(CONF_END_2_HOUR): cv.templatable(cv.int_range(min = 0, max = 23)),
+        cv.Required(CONF_END_2_MINUTE): cv.templatable(cv.int_range(min = 0, max = 59))
+    }))
+async def set_heating_curves_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    act = cg.new_Pvariable(action_id, template_arg, parent)
+
+    tmpl = await cg.templatable(config[CONF_START_1_HOUR], args, int)
+    cg.add(act.set_start_1_hour_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_START_1_MINUTE], args, int)
+    cg.add(act.set_start_1_minute_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_END_1_HOUR], args, int)
+    cg.add(act.set_end_1_hour_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_END_1_MINUTE], args, int)
+    cg.add(act.set_end_1_minute_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_START_2_HOUR], args, int)
+    cg.add(act.set_start_2_hour_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_START_2_MINUTE], args, int)
+    cg.add(act.set_start_2_minute_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_END_2_HOUR], args, int)
+    cg.add(act.set_end_2_hour_value(tmpl))
+    tmpl = await cg.templatable(config[CONF_END_2_MINUTE], args, int)
+    cg.add(act.set_end_2_minute_value(tmpl))
+
+    return act
+
+@automation.register_action(
     "luxtronik_v1.set_heating_curves",
     SetHeatingCurvesAction,
     cv.Schema(
@@ -166,30 +214,30 @@ async def set_heating_curves_action_to_code(config, action_id, template_arg, arg
 
     if CONF_HC_RETURN_OFFSET in config:
         tmpl = await cg.templatable(config[CONF_HC_RETURN_OFFSET], args, float)
-        cg.add(act.set_heating_curve_hc_return_offset_value(tmpl))
+        cg.add(act.set_hc_return_offset_value(tmpl))
     if CONF_HC_ENDPOINT in config:
         tmpl = await cg.templatable(config[CONF_HC_ENDPOINT], args, float)
-        cg.add(act.set_heating_curve_hc_endpoint_value(tmpl))
+        cg.add(act.set_hc_endpoint_value(tmpl))
     if CONF_HC_PARALLEL_SHIFT in config:
         tmpl = await cg.templatable(config[CONF_HC_PARALLEL_SHIFT], args, float)
-        cg.add(act.set_heating_curve_hc_parallel_shift_value(tmpl))
+        cg.add(act.set_hc_parallel_shift_value(tmpl))
     if CONF_HC_NIGHT_SETBACK in config:
         tmpl = await cg.templatable(config[CONF_HC_NIGHT_SETBACK], args, float)
-        cg.add(act.set_heating_curve_hc_night_setback_value(tmpl))
+        cg.add(act.set_hc_night_setback_value(tmpl))
     if CONF_HC_CONST_RETURN in config:
         tmpl = await cg.templatable(config[CONF_HC_CONST_RETURN], args, float)
-        cg.add(act.set_heating_curve_hc_constant_return_value(tmpl))
+        cg.add(act.set_hc_constant_return_value(tmpl))
     if CONF_MC1_ENDPOINT in config:
         tmpl = await cg.templatable(config[CONF_MC1_ENDPOINT], args, float)
-        cg.add(act.set_heating_curve_mc1_endpoint_value(tmpl))
+        cg.add(act.set_mc1_endpoint_value(tmpl))
     if CONF_MC1_PARALLEL_SHIFT in config:
         tmpl = await cg.templatable(config[CONF_MC1_PARALLEL_SHIFT], args, float)
-        cg.add(act.set_heating_curve_mc1_parallel_shift_value(tmpl))
+        cg.add(act.set_mc1_parallel_shift_value(tmpl))
     if CONF_MC1_NIGHT_SETBACK in config:
         tmpl = await cg.templatable(config[CONF_MC1_NIGHT_SETBACK], args, float)
-        cg.add(act.set_heating_curve_mc1_night_setback_value(tmpl))
+        cg.add(act.set_mc1_night_setback_value(tmpl))
     if CONF_MC1_CONST_FLOW in config:
         tmpl = await cg.templatable(config[CONF_MC1_CONST_FLOW], args, float)
-        cg.add(act.set_heating_curve_mc1_constant_flow_value(tmpl))
+        cg.add(act.set_mc1_constant_flow_value(tmpl))
 
     return act

--- a/components/luxtronik_v1/automation.h
+++ b/components/luxtronik_v1/automation.h
@@ -83,6 +83,87 @@ namespace esphome::luxtronik_v1
         TemplatableValue<float, Ts...> m_set_temperature_value;
     };
 
+    template<typename... Ts> class SetHotWaterOffTimesWeekAction : public Action<Ts...>
+    {
+    public:
+        SetHotWaterOffTimesWeekAction(Luxtronik *luxtronik)
+            : m_luxtronik(luxtronik)
+            , m_start_1_hour_value()
+            , m_start_1_minute_value()
+            , m_end_1_hour_value()
+            , m_end_1_minute_value()
+            , m_start_2_hour_value()
+            , m_start_2_minute_value()
+            , m_end_2_hour_value()
+            , m_end_2_minute_value()
+        {
+        }
+
+        void play(Ts... x) override
+        {
+            m_luxtronik->set_hot_water_off_times_week(
+                            m_start_1_hour_value.value(x...),
+                            m_start_1_minute_value.value(x...),
+                            m_end_1_hour_value.value(x...),
+                            m_end_1_minute_value.value(x...),
+                            m_start_2_hour_value.value(x...),
+                            m_start_2_minute_value.value(x...),
+                            m_end_2_hour_value.value(x...),
+                            m_end_2_minute_value.value(x...));
+        }
+
+        template<typename V> void set_start_1_hour_value(V value)
+        {
+            m_start_1_hour_value = value;
+        }
+
+        template<typename V> void set_start_1_minute_value(V value)
+        {
+            m_start_1_minute_value = value;
+        }
+
+        template<typename V> void set_end_1_hour_value(V value)
+        {
+            m_end_1_hour_value = value;
+        }
+
+        template<typename V> void set_end_1_minute_value(V value)
+        {
+            m_end_1_minute_value = value;
+        }
+
+        template<typename V> void set_start_2_hour_value(V value)
+        {
+            m_start_2_hour_value = value;
+        }
+
+        template<typename V> void set_start_2_minute_value(V value)
+        {
+            m_start_2_minute_value = value;
+        }
+
+        template<typename V> void set_end_2_hour_value(V value)
+        {
+            m_end_2_hour_value = value;
+        }
+
+        template<typename V> void set_end_2_minute_value(V value)
+        {
+            m_end_2_minute_value = value;
+        }
+
+    protected:
+        Luxtronik *m_luxtronik;
+        TemplatableValue<uint8_t, Ts...> m_start_1_hour_value;
+        TemplatableValue<uint8_t, Ts...> m_start_1_minute_value;
+        TemplatableValue<uint8_t, Ts...> m_end_1_hour_value;
+        TemplatableValue<uint8_t, Ts...> m_end_1_minute_value;
+        TemplatableValue<uint8_t, Ts...> m_start_2_hour_value;
+        TemplatableValue<uint8_t, Ts...> m_start_2_minute_value;
+        TemplatableValue<uint8_t, Ts...> m_end_2_hour_value;
+        TemplatableValue<uint8_t, Ts...> m_end_2_minute_value;
+    };
+
     template<typename... Ts> class SetHeatingCurvesAction : public Action<Ts...>
     {
     public:
@@ -125,47 +206,47 @@ namespace esphome::luxtronik_v1
             m_luxtronik->set_heating_curves(heating_curves);
         }
 
-        template<typename V> void set_heating_curve_hc_return_offset_value(V value)
+        template<typename V> void set_hc_return_offset_value(V value)
         {
             m_hc_return_offset_value = value;
         }
 
-        template<typename V> void set_heating_curve_hc_endpoint_value(V value)
+        template<typename V> void set_hc_endpoint_value(V value)
         {
             m_hc_endpoint_value = value;
         }
 
-        template<typename V> void set_heating_curve_hc_parallel_shift_value(V value)
+        template<typename V> void set_hc_parallel_shift_value(V value)
         {
             m_hc_parallel_shift_value = value;
         }
 
-        template<typename V> void set_heating_curve_hc_night_setback_value(V value)
+        template<typename V> void set_hc_night_setback_value(V value)
         {
             m_hc_night_setback_value = value;
         }
 
-        template<typename V> void set_heating_curve_hc_constant_return_value(V value)
+        template<typename V> void set_hc_constant_return_value(V value)
         {
             m_hc_const_return_value = value;
         }
 
-        template<typename V> void set_heating_curve_mc1_endpoint_value(V value)
+        template<typename V> void set_mc1_endpoint_value(V value)
         {
             m_mc1_endpoint_value = value;
         }
 
-        template<typename V> void set_heating_curve_mc1_parallel_shift_value(V value)
+        template<typename V> void set_mc1_parallel_shift_value(V value)
         {
             m_mc1_parallel_shift_value = value;
         }
 
-        template<typename V> void set_heating_curve_mc1_night_setback_value(V value)
+        template<typename V> void set_mc1_night_setback_value(V value)
         {
             m_mc1_night_setback_value = value;
         }
 
-        template<typename V> void set_heating_curve_mc1_constant_flow_value(V value)
+        template<typename V> void set_mc1_constant_flow_value(V value)
         {
             m_mc1_const_flow_value = value;
         }

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -95,6 +95,15 @@ namespace esphome::luxtronik_v1
         void add_dataset(const char* code);
         void set_operational_mode(OperationalModeType type, uint8_t value);
         void set_hot_water_set_temperature(float value);
+        void set_hot_water_off_times_week(
+                uint8_t start_1_hour,
+                uint8_t start_1_minute,
+                uint8_t end_1_hour,
+                uint8_t end_1_minute,
+                uint8_t start_2_hour,
+                uint8_t start_2_minute,
+                uint8_t end_2_hour,
+                uint8_t end_2_minute);
         void set_heating_curves(HeatingCurves& value);
 
 #ifdef USE_SENSOR

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -95,22 +95,31 @@ sensor:
     remote_adjuster_temperature:
       name: Temperatur Raumfernversteller
     heating_curve_hc_return_offset:
+      id: current_heating_curve_hc_return_offset
       name: Heizkurve Heizkreis Abweichung Rücklauf
     heating_curve_hc_endpoint:
+      id: current_heating_curve_hc_endpoint
       name: Heizkurve Heizkreis Endpunkt
     heating_curve_hc_parallel_shift:
+      id: current_heating_curve_hc_parallel_shift
       name: Heizkurve Heizkreis Parallelverschiebung
     heating_curve_hc_night_setback:
+      id: current_heating_curve_hc_night_setback
       name: Heizkurve Heizkreis Nachtabsenkung
     heating_curve_hc_constant_return:
+      id: current_heating_curve_hc_constant_return
       name: Heizkurve Heizkreis Festwert Rücklauf
     heating_curve_mc1_endpoint:
+      id: current_heating_curve_mc1_endpoint
       name: Heizkurve Mischkreis 1 Endpunkt
     heating_curve_mc1_parallel_shift:
+      id: current_heating_curve_mc1_parallel_shift
       name: Heizkurve Mischkreis 1 Parallelverschiebung
     heating_curve_mc1_night_setback:
+      id: current_heating_curve_mc1_night_setback
       name: Heizkurve Mischkreis 1 Nachtabsenkung
     heating_curve_mc1_constant_flow:
+      id: current_heating_curve_mc1_constant_flow
       name: Heizkurve Mischkreis 1 Festwert Vorlauf
     impulses_compressor_1:
       name: Impulse Verdichter 1
@@ -291,12 +300,16 @@ text_sensor:
     deactivation_5_time:
       name: Abschaltung 5 - Zeit
     hot_water_off_time_week_start_1:
+      id: current_hot_water_off_time_week_start_1
       name: Tägliche Sperrzeit Brauchwarmwasser 1 Beginn
     hot_water_off_time_week_end_1:
+      id: current_hot_water_off_time_week_end_1
       name: Tägliche Sperrzeit Brauchwarmwasser 1 Ende
     hot_water_off_time_week_start_2:
+      id: current_hot_water_off_time_week_start_2
       name: Tägliche Sperrzeit Brauchwarmwasser 2 Beginn
     hot_water_off_time_week_end_2:
+      id: current_hot_water_off_time_week_end_2
       name: Tägliche Sperrzeit Brauchwarmwasser 2 Ende
   - platform: wifi_info
     ip_address:
@@ -316,138 +329,350 @@ number:
     max_value: 65.0
     step: 0.5
     lambda: |-
-      return id(current_hot_water_set_temperature).state;
+      if (id(current_hot_water_set_temperature).has_state()) { return id(current_hot_water_set_temperature).state; }
+      else { return nullopt; }
     set_action:
       - luxtronik_v1.set_hot_water_set_temperature:
-          id: lwc_100
+          id: luxtronik_heat_pump
           value: !lambda "return x;"
       - lambda: "id(target_hot_water_set_temperature).publish_state(x);"
+  # number input for setting hour part of hot water off-time week start 1
+  - platform: template
+    id: target_hot_water_off_time_week_start_1_hour
+    name: Sperrzeit Brauchwarmwasser 1 Beginn Stunde
+    icon: mdi:alpha-h-box
+    unit_of_measurement: h
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 23
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_start_1);
+      if (!id(hot_water_off_times_week_edit_mode).state && cur->has_state())
+      {
+          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_start_1_hour).publish_state(x);"
+  # number input for setting minute part of hot water off-time week start 1
+  - platform: template
+    id: target_hot_water_off_time_week_start_1_minute
+    name: Sperrzeit Brauchwarmwasser 1 Beginn Minute
+    icon: mdi:alpha-m-box
+    unit_of_measurement: min
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 59
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_start_1);
+      if (!id(target_hot_water_off_time_week_start_1_minute).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_start_1_minute).publish_state(x);"
+  # number input for setting hour part of hot water off-time week end 1
+  - platform: template
+    id: target_hot_water_off_time_week_end_1_hour
+    name: Sperrzeit Brauchwarmwasser 1 Ende Stunde
+    icon: mdi:alpha-h-box
+    unit_of_measurement: h
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 23
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_end_1);
+      if (!id(target_hot_water_off_time_week_end_1_hour).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_end_1_hour).publish_state(x);"
+  # number input for setting minute part of hot water off-time week end 1
+  - platform: template
+    id: target_hot_water_off_time_week_end_1_minute
+    name: Sperrzeit Brauchwarmwasser 1 Ende Minute
+    icon: mdi:alpha-m-box
+    unit_of_measurement: min
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 59
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_end_1);
+      if (!id(target_hot_water_off_time_week_end_1_minute).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_end_1_minute).publish_state(x);"
+  # number input for setting hour part of hot water off-time week start 2
+  - platform: template
+    id: target_hot_water_off_time_week_start_2_hour
+    name: Sperrzeit Brauchwarmwasser 2 Beginn Stunde
+    icon: mdi:alpha-h-box
+    unit_of_measurement: h
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 23
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_start_2);
+      if (!id(target_hot_water_off_time_week_start_2_hour).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_start_2_hour).publish_state(x);"
+  # number input for setting minute part of hot water off-time week start 2
+  - platform: template
+    id: target_hot_water_off_time_week_start_2_minute
+    name: Sperrzeit Brauchwarmwasser 2 Beginn Minute
+    icon: mdi:alpha-m-box
+    unit_of_measurement: min
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 59
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_start_2);
+      if (!id(target_hot_water_off_time_week_start_2_minute).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_start_2_minute).publish_state(x);"
+  # number input for setting hour part of hot water off-time week end 2
+  - platform: template
+    id: target_hot_water_off_time_week_end_2_hour
+    name: Sperrzeit Brauchwarmwasser 2 Ende Stunde
+    icon: mdi:alpha-h-box
+    unit_of_measurement: h
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 23
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_end_2);
+      if (!id(target_hot_water_off_time_week_end_2_hour).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_end_2_hour).publish_state(x);"
+  # number input for setting minute part of hot water off-time week end 1
+  - platform: template
+    id: target_hot_water_off_time_week_end_2_minute
+    name: Sperrzeit Brauchwarmwasser 2 Ende Minute
+    icon: mdi:alpha-m-box
+    unit_of_measurement: min
+    entity_category: config
+    mode: box
+    min_value: 0
+    max_value: 59
+    step: 1
+    lambda: |-
+      auto cur = id(current_hot_water_off_time_week_end_2);
+      if (!id(target_hot_water_off_time_week_end_2_minute).has_state() && cur->has_state())
+      {
+          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
+      }
+      else
+      {
+          return nullopt;
+      }
+    set_action:
+      - lambda: "id(target_hot_water_off_time_week_end_2_minute).publish_state(x);"
   # number input for setting return temperature offset from heat curcuit heating curve
   - platform: template
-    id: heating_curve_hc_return_offset_value
+    id: target_heating_curve_hc_return_offset
     name: Abweichung Rücklauf von Heizkurve
     icon: mdi:plus-minus-variant
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
     mode: slider
-    optimistic: true
-    initial_value: 0.0
     min_value: -5.0
     max_value: 5.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_return_offset).has_state()) { return id(current_heating_curve_hc_return_offset).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_hc_return_offset).publish_state(x);"
   # number input for setting heat curcuit heating curve endpoint
   - platform: template
-    id: heating_curve_hc_endpoint_value
+    id: target_heating_curve_hc_endpoint
     name: Heizkurve Endpunkt
     icon: mdi:arrow-collapse-right
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
-    mode: slider
-    optimistic: true
-    initial_value: 35.0
+    mode: box
     min_value: 20.0
     max_value: 50.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_endpoint).has_state()) { return id(current_heating_curve_hc_endpoint).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_hc_endpoint).publish_state(x);"
   # number input for setting heat curcuit heating curve parallel shift
   - platform: template
-    id: heating_curve_hc_parallel_shift_value
+    id: target_heating_curve_hc_parallel_shift
     name: Heizkurve Parallelverschiebung
     icon: mdi:arrow-expand
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
-    mode: slider
-    optimistic: true
-    initial_value: 20.0
+    mode: box
     min_value: 0.0
     max_value: 40.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_parallel_shift).has_state()) { return id(current_heating_curve_hc_parallel_shift).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_hc_parallel_shift).publish_state(x);"
   # number input for setting heat curcuit heating curve night setback
   - platform: template
-    id: heating_curve_hc_night_setback_value
+    id: target_heating_curve_hc_night_setback
     name: Heizkurve Nachtabsenkung
     icon: mdi:moon-waning-crescent
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
     mode: slider
-    optimistic: true
-    initial_value: 0.0
     min_value: -10.0
     max_value: 0.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_night_setback).has_state()) { return id(current_heating_curve_hc_night_setback).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_hc_night_setback).publish_state(x);"
   # number input for setting heat curcuit constant return temperature
   - platform: template
-    id: heating_curve_hc_constant_return_value
+    id: target_heating_curve_hc_constant_return
     name: Heizkurve Festwert Rücklauf
     icon: mdi:format-vertical-align-center
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
-    mode: slider
-    optimistic: true
-    initial_value: 35.0
+    mode: box
     min_value: 0.0
     max_value: 50.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_constant_return).has_state()) { return id(current_heating_curve_hc_constant_return).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_hc_constant_return).publish_state(x);"
   # number input for setting mixed curcuit 1 endpoint
   - platform: template
-    id: heating_curve_mc1_endpoint_value
+    id: target_heating_curve_mc1_endpoint
     name: Heizkurve Mischkreis 1 Endpunkt
     icon: mdi:arrow-collapse-right
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
-    mode: slider
-    optimistic: true
-    initial_value: 35.0
+    mode: box
     min_value: 20.0
     max_value: 50.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_endpoint).has_state()) { return id(current_heating_curve_mc1_endpoint).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_mc1_endpoint).publish_state(x);"
   # number input for setting mixed curcuit 1 parallel shift
   - platform: template
-    id: heating_curve_mc1_parallel_shift_value
+    id: target_heating_curve_mc1_parallel_shift
     name: Heizkurve Mischkreis 1 Parallelverschiebung
     icon: mdi:arrow-expand
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
-    mode: slider
-    optimistic: true
-    initial_value: 20.0
+    mode: box
     min_value: 0.0
     max_value: 40.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_parallel_shift).has_state()) { return id(current_heating_curve_mc1_parallel_shift).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_mc1_parallel_shift).publish_state(x);"
   # number input for setting mixed curcuit 1 night setback
   - platform: template
-    id: heating_curve_mc1_night_setback_value
+    id: target_heating_curve_mc1_night_setback
     name: Heizkurve Mischkreis 1 Nachtabsenkung
     icon: mdi:moon-waning-crescent
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
     mode: slider
-    optimistic: true
-    initial_value: 0.0
     min_value: -10.0
     max_value: 0.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_night_setback).has_state()) { return id(current_heating_curve_mc1_night_setback).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_mc1_night_setback).publish_state(x);"
   # number input for setting mixed curcuit 1 constant flow temperature
   - platform: template
-    id: heating_curve_mc1_constant_flow_value
+    id: target_heating_curve_mc1_constant_flow
     name: Heizkurve Mischkreis 1 Festwert Vorlauf
     icon: mdi:format-vertical-align-center
     unit_of_measurement: °C
     device_class: temperature
     entity_category: config
-    mode: slider
-    optimistic: true
-    initial_value: 35.0
+    mode: box
     min_value: 0.0
     max_value: 50.0
     step: 0.5
+    lambda: |-
+      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_constant_flow).has_state()) { return id(current_heating_curve_mc1_constant_flow).state; }
+      else { return nullopt; }
+    set_action:
+      - lambda: "id(target_heating_curve_mc1_constant_flow).publish_state(x);"
 
 select:
   # selection for heating mode
@@ -462,15 +687,9 @@ select:
       - Party
       - Ferien
       - Aus
-    lambda: !lambda |-
-      if (!id(target_heating_mode).has_state() && id(current_heating_mode).has_state())
-      {
-          return id(current_heating_mode).state;
-      }
-      else
-      {
-          return esphome::nullopt;
-      }
+    lambda: |-
+      if (id(current_heating_mode).has_state()) { return id(current_heating_mode).state; }
+      else { return nullopt; }
     set_action:
       - luxtronik_v1.set_heating_mode:
           id: luxtronik_heat_pump
@@ -490,24 +709,36 @@ select:
       - Party
       - Ferien
       - Aus
-    lambda: !lambda |-
-      if (!id(target_hot_water_mode).has_state() && id(current_hot_water_mode).has_state())
-      {
-          return id(current_hot_water_mode).state;
-      }
-      else
-      {
-          return esphome::nullopt;
-      }
+    lambda: |-
+      if (id(current_hot_water_mode).has_state()) { return id(current_hot_water_mode).state; }
+      else { return nullopt; }
     set_action:
       - luxtronik_v1.set_hot_water_mode:
-          id: lwc_100
+          id: luxtronik_heat_pump
           mode: !lambda |-
             auto idx = id(target_hot_water_mode).index_of(x);
             return idx.has_value() ? idx.value() : 255;
       - lambda: "id(target_hot_water_mode).publish_state(x);"
 
 button:
+  # button for sending hot water off-times week to Luxtronik heating control unit
+  - platform: template
+    name: Brauchwarmwasser Sperrzeiten setzen
+    icon: mdi:download
+    entity_category: config
+    on_press:
+      - luxtronik_v1.set_hot_water_off_times_week:
+          id: luxtronik_heat_pump
+          start_1_hour: !lambda "return id(target_hot_water_off_time_week_start_1_hour).state;"
+          start_1_minute: !lambda "return id(target_hot_water_off_time_week_start_1_minute).state;"
+          end_1_hour: !lambda "return id(target_hot_water_off_time_week_end_1_hour).state;"
+          end_1_minute: !lambda "return id(target_hot_water_off_time_week_end_1_minute).state;"
+          start_2_hour: !lambda "return id(target_hot_water_off_time_week_start_2_hour).state;"
+          start_2_minute: !lambda "return id(target_hot_water_off_time_week_start_2_minute).state;"
+          end_2_hour: !lambda "return id(target_hot_water_off_time_week_end_2_hour).state;"
+          end_2_minute: !lambda "return id(target_hot_water_off_time_week_end_2_minute).state;"
+      - switch.turn_off:
+          id: hot_water_off_times_week_edit_mode
   # button for sending heating curves to Luxtronik heating control unit
   - platform: template
     name: Heizkurve setzen
@@ -516,12 +747,12 @@ button:
     on_press:
       - luxtronik_v1.set_heating_curves:
           id: luxtronik_heat_pump
-          hc_return_offset: !lambda "return id(heating_curve_hc_return_offset_value).state;"
-          hc_endpoint: !lambda "return id(heating_curve_hc_endpoint_value).state;"
-          hc_parallel_shift: !lambda "return id(heating_curve_hc_parallel_shift_value).state;"
-          hc_night_setback: !lambda "return id(heating_curve_hc_night_setback_value).state;"
-          hc_const_return: !lambda "return id(heating_curve_hc_constant_return_value).state;"
-          mc1_endpoint: !lambda "return id(heating_curve_mc1_endpoint_value).state;"
-          mc1_parallel_shift: !lambda "return id(heating_curve_mc1_parallel_shift_value).state;"
-          mc1_night_setback: !lambda "return id(heating_curve_mc1_night_setback_value).state;"
-          mc1_const_flow: !lambda "return id(heating_curve_mc1_constant_flow_value).state;"
+          hc_return_offset: !lambda "return id(target_heating_curve_hc_return_offset).state;"
+          hc_endpoint: !lambda "return id(target_heating_curve_hc_endpoint).state;"
+          hc_parallel_shift: !lambda "return id(target_heating_curve_hc_parallel_shift).state;"
+          hc_night_setback: !lambda "return id(target_heating_curve_hc_night_setback).state;"
+          hc_const_return: !lambda "return id(target_heating_curve_hc_constant_return).state;"
+          mc1_endpoint: !lambda "return id(target_heating_curve_mc1_endpoint).state;"
+          mc1_parallel_shift: !lambda "return id(target_heating_curve_mc1_parallel_shift).state;"
+          mc1_night_setback: !lambda "return id(target_heating_curve_mc1_night_setback).state;"
+          mc1_const_flow: !lambda "return id(target_heating_curve_mc1_constant_flow).state;"

--- a/test/luxtronik_simu.py
+++ b/test/luxtronik_simu.py
@@ -29,6 +29,7 @@ import serial
 heating_mode = '4'
 hot_water_mode = '0'
 hot_water_set_temp = '460'
+hot_water_off_times_week = '6;0;23;59;0;0;2;30'
 heating_curve = '0;320;220;0;350;350;200;0;350'
 
 def respond(str):
@@ -77,8 +78,8 @@ def send_deactivations():
 def send_information():
     respond('1700;12;12; V2.33;1;5;22;1;24;6;56;44;0;0')
 
-def send_hot_water_off_times_week():
-    respond('3200;8;6;0;23;59;0;0;2;30')
+def send_hot_water_off_times_week(cmd):
+    respond(f'{cmd};8;{hot_water_off_times_week}')
 
 def send_heating_curve(cmd):
     respond(f'{cmd};9;{heating_curve}')
@@ -98,6 +99,7 @@ def parse_command(cmd):
     global heating_curve
     global heating_mode
     global hot_water_mode
+    global hot_water_off_times_week
     global hot_water_set_temp
 
     try:
@@ -132,7 +134,13 @@ def parse_command(cmd):
             send_information()
             ser.write(b'1800;8\r\n')
         elif cmd_str == '3200':
-            send_hot_water_off_times_week()
+            send_hot_water_off_times_week('3200')
+        elif cmd_str.startswith('3201'):
+            if len(cmd_str) == 4:
+                send_hot_water_off_times_week('3201')
+            elif len(cmd_str) > 7:
+                hot_water_off_times_week = cmd_str[7:]
+                send_hot_water_off_times_week('3201')
         elif cmd_str == '3400':
             send_heating_curve('3400')
         elif cmd_str.startswith('3401'):


### PR DESCRIPTION
Adds the possibility to change the daily hot water off-times configured in the Luxtronik heating control unit. For this purpose, the new action `set_hot_water_off_times_week` has been added. It can be called either from a Home Assistant automation or from some UI elements like number inputs in combination with a button.