### PR TITLE
Helper UI components for configuring heating control unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,39 @@ number:
           value: !lambda "return x;"
 ```
 
+#### Auswahl-Komponente
+Die Luxtronik-Komponente stellt eine spezifische Auswahl-Komponente ähnlich der Template-Auswahl-Komponente zur Verfügung. Diese kann über die Benutzeroberfläche gesteuert werden, kann die aktuelle Auswahl aber auch von einem Sensor der Luxtronik Heizungssteuerung übernehmen.
+
+Zusätzlich zu allen Eigenschaften der [Auswahl-Komponente](https://www.esphome.io/components/select) können noch folgende Einstellungen konfiguriert werden.
+
+| Eigenschaft | Typ | Benötigt | Wertebereich | Standardwert | Beschreibung |
+| ----------- | --- | -------- | ------------ |------------- | ------------ |
+| `options` | Liste | ja | - | - | Liste der Auswahlmöglichkeiten |
+| `set_action` | [Aktion](https://www.esphome.io/automations/actions#actions) | nein | - | - | Aktionen, die ausgeführt werden sollen, wenn die Auswahl von der Benutzeroberfläche aus geändert wird (Lambda-Funktionen steht der Name der neuen Auswahl in der Variable `x` und der Index der neuen Auswahl in der Variable `i` zur Verfügung) |
+| `data_source` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | nein | - | - | ID eines [Text-Sensors](https://www.esphome.io/components/text_sensor), der die Luxtronik-seitige Auswahl zur Verfügung stellt |
+
+Die Luxtronik Auswahl-Komponente ist standardmäßig der Entitätenkategorie `config` zugeordnet. Diese Standardeigenschaft kann bei Bedarf überschrieben werden.
+
+##### Beispiel
+```yaml
+select:
+  - platform: luxtronik_v1
+    id: target_heating_mode
+    name: Betriebsart Heizung
+    icon: mdi:radiator
+    options:
+      - Automatik
+      - Zweiter Wärmeerzeuger
+      - Party
+      - Ferien
+      - Aus
+    data_source: current_heating_mode
+    set_action:
+      - luxtronik_v1.set_heating_mode:
+          id: luxtronik_heat_pump
+          mode: !lambda "return i;"
+```
+
 ### Aktionen
 Die Luxtronik-Komponente stellt verschiedene Aktionen zur Verfügung, um die Luxtronik Heizungssteuerung zu programmieren.
 
@@ -1057,6 +1090,39 @@ number:
       - luxtronik_v1.set_hot_water_set_temperature:
           id: luxtronik_heat_pump
           value: !lambda "return x;"
+```
+
+#### Select Component
+The Luxtronik component provides a specific select component similar to the template select component. It can be controlled from the user interface, but can also accept the current selection from a sensor of the Luxtronik heating control unit.
+
+In addition to all the properties of the [select component](https://www.esphome.io/components/select), the following settings can also be configured.
+
+| Property | Type | Mandatory | Value Range | Default Value | Description |
+| -------- | ---- | --------- | ----------- |-------------- | ----------- |
+| `options` | List | yes | - | - | List of selection options |
+| `set_action` | [Action](https://www.esphome.io/automations/actions#actions) | no | - | - | Actions to be performed when the selection is changed from the user interface (lambda functions can access the name of the new selection via variable `x` and the index of the new selection via variable `i`) |
+| `data_source` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | no | - | - | ID of a [text sensor](https://www.esphome.io/components/text_sensor) that provides the Luxtronik-side selection |
+
+By default, the Luxtronik select component is assigned to the entity category `config`. This standard property can be overwritten if required.
+
+##### Example
+```yaml
+select:
+  - platform: luxtronik_v1
+    id: target_heating_mode
+    name: Betriebsart Heizung
+    icon: mdi:radiator
+    options:
+      - Automatik
+      - Zweiter Wärmeerzeuger
+      - Party
+      - Ferien
+      - Aus
+    data_source: current_heating_mode
+    set_action:
+      - luxtronik_v1.set_heating_mode:
+          id: luxtronik_heat_pump
+          mode: !lambda "return i;"
 ```
 
 ### Actions

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Dieses Projekt wurde stark von der [Luxtronik V1 ESPHome-Komponente](https://git
     - [Numerische Sensoren](#numerische-sensoren)
     - [Binäre Sensoren](#binäre-sensoren)
     - [Textsensoren](#textsensoren)
+  - [Aktoren](#aktoren)
   - [Aktionen](#aktionen)
 - [Luxtronik-Konfiguration](#luxtronik-konfiguration)
 - [Hilfe/Unterstützung](SUPPORT.md)
@@ -93,8 +94,8 @@ external_components:
 
 Die folgenden generischen Einstellungen können konfiguriert werden:
 
-| Option | Typ | Benötigt | Wertebereich | Standardwert | Beschreibung |
-| ------ | --- | -------- | ------------ |------------- | ------------ |
+| Eigenschaft | Typ | Benötigt | Wertebereich | Standardwert | Beschreibung |
+| ----------- | --- | -------- | ------------ |------------- | ------------ |
 | `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | nein | - | - | Instanz der Luxtronik-Komponente |
 | `uart_id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | ja | - | - | Konfigurierte [UART-Komponente](#uart-komponente) zum Abrufen der Daten von der Luxtronik Heizungssteuerung |
 | `update_interval` | Zahl | nein | Positive Zeitdauer | 60s | Das Intervall, in dem die Komponente Daten vom Heizungssteuergerät abruft |
@@ -439,6 +440,41 @@ text_sensor:
       name: Letzte Abschaltung - Zeit
 ```
 
+### Aktoren
+Die Luxtronik-Komponente stellt Aktoren zur Verfügung, die für die Eingabe von Daten zur Programmierung der Luxtronik Heizungssteuerung dienen.
+
+#### Zahlen-Komponente
+Die Luxtronik-Komponente stellt eine spezifische Zahlen-Komponente ähnlich der Template-Zahlen-Komponente zur Verfügung. Diese nimmt Benutzereingaben entgegen, kann den Wert aber auch von einem Sensor der Luxtronik Heizungssteuerung übernehmen. Zudem kann ein Schalter für einen Editiermodus konfiguriert werden, um ein Überschreiben des Wertes bei einer Sensoraktualisierung zu vermeiden, solange man noch die Eingaben verändert, ohne diese an die Luxtronik Heizungssteuerung geschickt zu haben.
+
+Zusätzlich zu allen Eigenschaften der [Zahlen-Komponente](https://www.esphome.io/components/number) können noch folgende Einstellungen konfiguriert werden.
+
+| Eigenschaft | Typ | Benötigt | Wertebereich | Standardwert | Beschreibung |
+| ----------- | --- | -------- | ------------ |------------- | ------------ |
+| `min_value` | Zahl | ja | unbegrenzt | - | Kleinstmöglicher Eingabewert |
+| `max_value` | Zahl | ja | unbegrenzt | - | Größtmöglicher Eingabewert |
+| `step` | Zahl | ja | >=&nbsp;0 | 0.5 | Schrittweite für den Eingabewert |
+| `set_action` | [Aktion](https://www.esphome.io/automations/actions#actions) | nein | - | - | Aktionen, die ausgeführt werden sollen, wenn der Wert von der Benutzeroberfläche aus geändert wird (der neue Wert steht Lambda-Funktionen in der Variable `x` zur Verfügung) |
+| `data_source` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | nein | - | - | ID eines [Sensors](https://www.esphome.io/components/sensor), der den Luxtronik-seitigen Wert zur Verfügung stellt |
+| `edit_mode_switch` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | nein | - | - | ID eines [Schalters](https://www.esphome.io/components/switch), der den Editiermodus steuert |
+
+Die Luxtronik Zahlen-Komponente ist standardmäßig der Entitätenkategorie `config` zugeordnet und besitzt die Geräteklasse `temperature` sowie die Einheit `°C`. Diese Standardeigenschaften können bei Bedarf überschrieben werden.
+
+##### Beispiel
+```yaml
+number:
+  - platform: luxtronik_v1
+    name: Soll-Temperatur Brauchwarmwasser
+    icon: mdi:coolant-temperature
+    mode: slider
+    min_value: 30.0
+    max_value: 65.0
+    data_source: current_hot_water_set_temperature
+    set_action:
+      - luxtronik_v1.set_hot_water_set_temperature:
+          id: luxtronik_heat_pump
+          value: !lambda "return x;"
+```
+
 ### Aktionen
 Die Luxtronik-Komponente stellt verschiedene Aktionen zur Verfügung, um die Luxtronik Heizungssteuerung zu programmieren.
 
@@ -568,6 +604,7 @@ This project was heavily inspired by the [Luxtronik V1 ESPHome component](https:
     - [Numeric Sensors](#numeric-sensors)
     - [Binary Sensors](#binary-sensors)
     - [Text Sensors](#text-sensors)
+  - [Actors](#actors)
   - [Actions](#actions)
 - [Luxtronik Configuration](#luxtronik-configuration)
 - [Help/Support](SUPPORT.md#-getting-support-for-esphome-luxtronik-v1)
@@ -642,8 +679,8 @@ external_components:
 
 The following generic configuration items can be configured:
 
-| Option | Type | Mandatory | Value Range | Default Value | Description |
-| ------ | ---- | --------- | ----------- |-------------- | ----------- |
+| Property | Type | Mandatory | Value Range | Default Value | Description |
+| -------- | ---- | --------- | ----------- |-------------- | ----------- |
 | `id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | no | n/a | n/a | Luxtronik component instance |
 | `uart_id` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | yes | n/a | n/a | Configured [UART component](#uart-component) for retrieving data from the Luxtronik heating control unit |
 | `update_interval` | Number | no | Positive duration | 60s | The interval how often the component fetches data from the heating control unit |
@@ -985,6 +1022,41 @@ text_sensor:
       name: Letzte Abschaltung - Code
     deactivation_5_time:
       name: Letzte Abschaltung - Zeit
+```
+
+### Actors
+The Luxtronik component provides actors that are used to input data for programming the Luxtronik heating control unit.
+
+#### Number Component
+The Luxtronik component provides a specific number component similar to the template number component. It accepts user input, but can also accept the value from a sensor of the Luxtronik heating control unit. In addition, a switch for an editing mode can be configured to prevent the value from being overwritten when the sensor is updated as long as the entries are still being changed without having sent them to the Luxtronik heating control unit.
+
+In addition to all the properties of the [number component](https://www.esphome.io/components/number), the following settings can also be configured.
+
+| Property | Type | Mandatory | Value Range | Default Value | Description |
+| -------- | ---- | --------- | ----------- |-------------- | ----------- |
+| `min_value` | Number | yes | unlimited | - | Smallest possible input value |
+| `max_value` | Number | yes | unlimited | - | Largest possible input value |
+| `step` | Number | yes | >=&nbsp;0 | 0.5 | Step for input value |
+| `set_action` | [Action](https://www.esphome.io/automations/actions#actions) | no | - | - | Actions to be performed when the value is changed from the user interface (the new value is available to lambda functions in the variable `x`) |
+| `data_source` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | no | - | - | ID of a [sensor](https://www.esphome.io/components/sensor) that provides the Luxtronik-side value |
+| `edit_mode_switch` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | no | - | - | ID of a [switch](https://www.esphome.io/components/switch) that controls the editing mode |
+
+By default, the Luxtronik number component is assigned to the entity category `config` and has the device class `temperature` and the unit of measurement `°C`. These standard properties can be overwritten if required.
+
+##### Example
+```yaml
+number:
+  - platform: luxtronik_v1
+    name: Soll-Temperatur Brauchwarmwasser
+    icon: mdi:coolant-temperature
+    mode: slider
+    min_value: 30.0
+    max_value: 65.0
+    data_source: current_hot_water_set_temperature
+    set_action:
+      - luxtronik_v1.set_hot_water_set_temperature:
+          id: luxtronik_heat_pump
+          value: !lambda "return x;"
 ```
 
 ### Actions

--- a/README.md
+++ b/README.md
@@ -508,6 +508,29 @@ select:
           mode: !lambda "return i;"
 ```
 
+#### Zeitauswahl-Komponente
+Die Luxtronik-Komponente stellt eine spezifische Zeitauswahl-Komponente ähnlich der Template-Zeitauswahl-Komponente zur Verfügung. Diese nimmt Benutzereingaben entgegen, kann den Wert aber auch von einem Sensor der Luxtronik Heizungssteuerung übernehmen. Zudem kann ein Schalter für einen Editiermodus konfiguriert werden, um ein Überschreiben des Wertes bei einer Sensoraktualisierung zu vermeiden, solange man noch die Eingaben verändert, ohne diese an die Luxtronik Heizungssteuerung geschickt zu haben.
+
+Zusätzlich zu allen Eigenschaften der [Datums-/Zeitauswahl-Komponente](https://www.esphome.io/components/datetime) können noch folgende Einstellungen konfiguriert werden.
+
+| Eigenschaft | Typ | Benötigt | Wertebereich | Standardwert | Beschreibung |
+| ----------- | --- | -------- | ------------ |------------- | ------------ |
+| `set_action` | [Aktion](https://www.esphome.io/automations/actions#actions) | nein | - | - | Aktionen, die ausgeführt werden sollen, wenn der Wert von der Benutzeroberfläche aus geändert wird (der neue Wert steht Lambda-Funktionen in der Variable `x` zur Verfügung) |
+| `data_source` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | nein | - | - | ID eines [Text Sensors](https://www.esphome.io/components/text_sensor), der den Luxtronik-seitigen Wert zur Verfügung stellt |
+| `edit_mode_switch` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | nein | - | - | ID eines [Schalters](https://www.esphome.io/components/switch), der den Editiermodus steuert |
+
+Die Luxtronik Zeitauswahl-Komponente ist standardmäßig der Entitätenkategorie `config` zugeordnet. Diese Standardeigenschaft kann bei Bedarf überschrieben werden.
+
+##### Beispiel
+```yaml
+datetime:
+  - platform: luxtronik_v1
+    id: target_hot_water_off_time_week_start_1
+    name: Tägliche Sperrzeit Brauchwarmwasser 1 Beginn
+    data_source: current_hot_water_off_time_week_start_1
+    edit_mode_switch: hot_water_off_times_week_edit_mode
+```
+
 ### Aktionen
 Die Luxtronik-Komponente stellt verschiedene Aktionen zur Verfügung, um die Luxtronik Heizungssteuerung zu programmieren.
 
@@ -1123,6 +1146,29 @@ select:
       - luxtronik_v1.set_heating_mode:
           id: luxtronik_heat_pump
           mode: !lambda "return i;"
+```
+
+#### Time Select Component
+The Luxtronik component provides a specific time select component similar to the template time select component. It accepts user input, but can also accept the value from a sensor of the Luxtronik heating control unit. In addition, a switch for an editing mode can be configured to prevent the value from being overwritten when the sensor is updated as long as the entries are still being changed without having sent them to the Luxtronik heating control unit.
+
+In addition to all the properties of the [datetime component](https://www.esphome.io/components/datetime), the following settings can also be configured.
+
+| Property | Type | Mandatory | Value Range | Default Value | Description |
+| -------- | ---- | --------- | ----------- |-------------- | ----------- |
+| `set_action` | [Action](https://www.esphome.io/automations/actions#actions) | no | - | - | Actions to be performed when the value is changed from the user interface (the new value is available to lambda functions in the variable `x`) |
+| `data_source` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | no | - | - | ID of a [text sensor](https://www.esphome.io/components/text_sensor) that provides the Luxtronik-side value |
+| `edit_mode_switch` | [ID](https://www.esphome.io/guides/configuration-types#config-id) | no | - | - | ID of a [switch](https://www.esphome.io/components/switch) that controls the editing mode |
+
+By default, the Luxtronik time select component is assigned to the entity category `config`. This standard property can be overwritten if required.
+
+##### Example
+```yaml
+datetime:
+  - platform: luxtronik_v1
+    id: target_hot_water_off_time_week_start_1
+    name: Tägliche Sperrzeit Brauchwarmwasser 1 Beginn
+    data_source: current_hot_water_off_time_week_start_1
+    edit_mode_switch: hot_water_off_times_week_edit_mode
 ```
 
 ### Actions

--- a/components/luxtronik_v1/__init__.py
+++ b/components/luxtronik_v1/__init__.py
@@ -62,6 +62,9 @@ CONF_START_2_MINUTE = "start_2_minute"
 CONF_END_2_HOUR     = "end_2_hour"
 CONF_END_2_MINUTE   = "end_2_minute"
 
+CONF_DATA_SOURCE      = "data_source"
+CONF_EDIT_MODE_SWITCH = "edit_mode_switch"
+
 TYPE_HEATING_MODE   = 0
 TYPE_HOT_WATER_MODE = 1
 

--- a/components/luxtronik_v1/datetime/__init__.py
+++ b/components/luxtronik_v1/datetime/__init__.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Jens-Uwe Rossbach
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import esphome.codegen           as cg
+import esphome.config_validation as cv
+
+from esphome            import automation
+from esphome.components import datetime, switch, text_sensor
+from esphome.const      import (
+    CONF_SET_ACTION
+)
+from ..                 import (
+    luxtronik_ns,
+    CONF_DATA_SOURCE,
+    CONF_EDIT_MODE_SWITCH
+)
+
+
+LuxtronikTime = luxtronik_ns.class_("LuxtronikTime", datetime.TimeEntity)
+EntityCategory = cg.global_ns.enum("esphome::EntityCategory")
+
+CONFIG_SCHEMA = datetime.time_schema(LuxtronikTime).extend(
+{
+    cv.Optional(CONF_SET_ACTION): automation.validate_automation(single = True),
+    cv.Optional(CONF_DATA_SOURCE): cv.use_id(text_sensor.TextSensor),
+    cv.Optional(CONF_EDIT_MODE_SWITCH): cv.use_id(switch.Switch)
+})
+
+
+async def to_code(config):
+    tim = await datetime.new_datetime(config)
+    cg.add(tim.set_entity_category(EntityCategory.ENTITY_CATEGORY_CONFIG))
+
+    if CONF_DATA_SOURCE in config:
+        sns = await cg.get_variable(config[CONF_DATA_SOURCE])
+        cg.add(tim.set_source_sensor(sns))
+
+    if CONF_EDIT_MODE_SWITCH in config:
+        swt = await cg.get_variable(config[CONF_EDIT_MODE_SWITCH])
+        cg.add(tim.set_edit_mode_switch(swt))
+
+    if CONF_SET_ACTION in config:
+        await automation.build_automation(
+            tim.get_set_trigger(), [(cg.ESPTime, "x")], config[CONF_SET_ACTION])

--- a/components/luxtronik_v1/datetime/luxtronik_time.cpp
+++ b/components/luxtronik_v1/datetime/luxtronik_time.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include "luxtronik_time.h"
+
+
+#ifdef USE_DATETIME_TIME
+
+namespace esphome::luxtronik_v1
+{
+    void LuxtronikTime::control(const datetime::TimeCall &call)
+    {
+        bool has_hour = call.get_hour().has_value();
+        bool has_minute = call.get_minute().has_value();
+
+        ESPTime value = {};
+
+        if (has_hour)
+        {
+            hour_ = *call.get_hour();
+            value.hour = hour_;
+        }
+        if (has_minute)
+        {
+            minute_ = *call.get_minute();
+            value.minute = minute_;
+        }
+
+        second_ = 0;
+        value.second = 0;
+
+        m_set_trigger.trigger(value);
+        publish_state();
+    }
+
+#ifdef USE_TEXT_SENSOR
+    void LuxtronikTime::set_source_sensor(text_sensor::TextSensor* sensor)
+    {
+        m_source_sensor = sensor;
+
+        m_source_sensor->add_on_state_callback([this](std::string value)
+        {
+#ifdef USE_SWITCH
+            bool edit_mode = (m_edit_mode_switch != nullptr) ? m_edit_mode_switch->state : false;
+#else
+            bool edit_mode = false;
+#endif
+
+            if (!edit_mode)
+            {
+                hour_ = static_cast<uint8_t>(atoi(value.substr(0, value.find(':')).c_str()));
+                minute_ = static_cast<uint8_t>(atoi(value.substr(value.find(':') + 1).c_str()));
+                second_ = 0;
+
+                publish_state();
+            }
+        });
+    }
+#endif
+}  // namespace esphome::luxtronik_v1
+
+#endif

--- a/components/luxtronik_v1/datetime/luxtronik_time.h
+++ b/components/luxtronik_v1/datetime/luxtronik_time.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_DATETIME_TIME
+
+#include "esphome/core/automation.h"
+#include "esphome/components/datetime/time_entity.h"
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+
+
+namespace esphome::luxtronik_v1
+{
+    class LuxtronikTime
+            : public datetime::TimeEntity
+    {
+    public:
+        LuxtronikTime()
+            : datetime::TimeEntity()
+            , m_set_trigger()
+#ifdef USE_TEXT_SENSOR
+            , m_source_sensor(nullptr)
+#endif
+#ifdef USE_SWITCH
+            , m_edit_mode_switch(nullptr)
+#endif
+        {
+        }
+
+        Trigger<ESPTime>* get_set_trigger() { return &m_set_trigger; }
+#ifdef USE_TEXT_SENSOR
+        void set_source_sensor(text_sensor::TextSensor* sensor);
+#endif
+#ifdef USE_SWITCH
+        void set_edit_mode_switch(switch_::Switch* swt) { m_edit_mode_switch = swt; }
+#endif
+
+    protected:
+        void control(const datetime::TimeCall &call) override;
+
+        Trigger<ESPTime> m_set_trigger;
+#ifdef USE_TEXT_SENSOR
+        text_sensor::TextSensor* m_source_sensor;
+#endif
+#ifdef USE_SWITCH
+        switch_::Switch* m_edit_mode_switch;
+#endif
+    };
+}  // namespace esphome::luxtronik_v1
+
+#endif

--- a/components/luxtronik_v1/number/__init__.py
+++ b/components/luxtronik_v1/number/__init__.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Jens-Uwe Rossbach
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import esphome.codegen           as cg
+import esphome.config_validation as cv
+
+from esphome            import automation
+from esphome.components import number, switch, sensor
+from esphome.const      import (
+    ENTITY_CATEGORY_CONFIG,
+    DEVICE_CLASS_TEMPERATURE,
+    UNIT_CELSIUS,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_SET_ACTION,
+    CONF_STEP
+)
+from ..                 import (
+    luxtronik_ns,
+    CONF_DATA_SOURCE,
+    CONF_EDIT_MODE_SWITCH
+)
+
+
+LuxtronikNumber = luxtronik_ns.class_("LuxtronikNumber", number.Number)
+
+CONFIG_SCHEMA = number.number_schema(
+        LuxtronikNumber,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        unit_of_measurement=UNIT_CELSIUS).extend(
+{
+    cv.Required(CONF_MIN_VALUE): cv.float_,
+    cv.Required(CONF_MAX_VALUE): cv.float_,
+    cv.Optional(CONF_STEP, default = 0.5): cv.positive_float,
+    cv.Optional(CONF_SET_ACTION): automation.validate_automation(single = True),
+    cv.Optional(CONF_DATA_SOURCE): cv.use_id(sensor.Sensor),
+    cv.Optional(CONF_EDIT_MODE_SWITCH): cv.use_id(switch.Switch)
+})
+
+
+async def to_code(config):
+    num = await number.new_number(
+                        config,
+                        min_value = config[CONF_MIN_VALUE],
+                        max_value = config[CONF_MAX_VALUE],
+                        step = config[CONF_STEP])
+
+    if CONF_DATA_SOURCE in config:
+        sns = await cg.get_variable(config[CONF_DATA_SOURCE])
+        cg.add(num.set_source_sensor(sns))
+
+    if CONF_EDIT_MODE_SWITCH in config:
+        swt = await cg.get_variable(config[CONF_EDIT_MODE_SWITCH])
+        cg.add(num.set_edit_mode_switch(swt))
+
+    if CONF_SET_ACTION in config:
+        await automation.build_automation(
+            num.get_set_trigger(), [(float, "x")], config[CONF_SET_ACTION])

--- a/components/luxtronik_v1/number/luxtronik_number.cpp
+++ b/components/luxtronik_v1/number/luxtronik_number.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include "luxtronik_number.h"
+
+
+#ifdef USE_NUMBER
+
+namespace esphome::luxtronik_v1
+{
+    void LuxtronikNumber::control(float value)
+    {
+        m_set_trigger.trigger(value);
+        publish_state(value);
+    }
+
+#ifdef USE_SENSOR
+    void LuxtronikNumber::set_source_sensor(sensor::Sensor* sensor)
+    {
+        m_source_sensor = sensor;
+
+        m_source_sensor->add_on_state_callback([this](float value)
+        {
+#ifdef USE_SWITCH
+            bool edit_mode = (m_edit_mode_switch != nullptr) ? m_edit_mode_switch->state : false;
+#else
+            bool edit_mode = false;
+#endif
+
+            if (!edit_mode)
+            {
+                publish_state(value);
+            }
+        });
+    }
+#endif
+}  // namespace esphome::luxtronik_v1
+
+#endif

--- a/components/luxtronik_v1/number/luxtronik_number.h
+++ b/components/luxtronik_v1/number/luxtronik_number.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_NUMBER
+
+#include "esphome/core/automation.h"
+#include "esphome/components/number/number.h"
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+
+
+namespace esphome::luxtronik_v1
+{
+    class LuxtronikNumber
+            : public number::Number
+    {
+    public:
+        LuxtronikNumber()
+            : number::Number()
+            , m_set_trigger()
+#ifdef USE_SENSOR
+            , m_source_sensor(nullptr)
+#endif
+#ifdef USE_SWITCH
+            , m_edit_mode_switch(nullptr)
+#endif
+        {
+        }
+
+        Trigger<float>* get_set_trigger() { return &m_set_trigger; }
+#ifdef USE_SENSOR
+        void set_source_sensor(sensor::Sensor* sensor);
+#endif
+#ifdef USE_SWITCH
+        void set_edit_mode_switch(switch_::Switch* swt) { m_edit_mode_switch = swt; }
+#endif
+
+    protected:
+        void control(float value) override;
+
+        Trigger<float> m_set_trigger;
+#ifdef USE_SENSOR
+        sensor::Sensor* m_source_sensor;
+#endif
+#ifdef USE_SWITCH
+        switch_::Switch* m_edit_mode_switch;
+#endif
+    };
+}  // namespace esphome::luxtronik_v1
+
+#endif

--- a/components/luxtronik_v1/select/__init__.py
+++ b/components/luxtronik_v1/select/__init__.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025 Jens-Uwe Rossbach
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import esphome.codegen           as cg
+import esphome.config_validation as cv
+
+from esphome            import automation
+from esphome.components import select, text_sensor
+from esphome.const      import (
+    ENTITY_CATEGORY_CONFIG,
+    CONF_OPTIONS,
+    CONF_SET_ACTION
+)
+from ..                 import (
+    luxtronik_ns,
+    CONF_DATA_SOURCE
+)
+
+
+LuxtronikSelect = luxtronik_ns.class_("LuxtronikSelect", select.Select)
+
+CONFIG_SCHEMA = select.select_schema(
+        LuxtronikSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG).extend(
+{
+    cv.Required(CONF_OPTIONS): cv.All(cv.ensure_list(cv.string_strict), cv.Length(min = 1, max = 255)),
+    cv.Optional(CONF_SET_ACTION): automation.validate_automation(single = True),
+    cv.Optional(CONF_DATA_SOURCE): cv.use_id(text_sensor.TextSensor)
+})
+
+
+async def to_code(config):
+        sel = await select.new_select(
+                            config,
+                            options = config[CONF_OPTIONS])
+
+        if CONF_DATA_SOURCE in config:
+            sns = await cg.get_variable(config[CONF_DATA_SOURCE])
+            cg.add(sel.set_source_sensor(sns))
+
+        if CONF_SET_ACTION in config:
+            await automation.build_automation(
+                sel.get_set_trigger(), [(cg.std_string, "x"), (cg.uint8, "i")], config[CONF_SET_ACTION])

--- a/components/luxtronik_v1/select/luxtronik_select.cpp
+++ b/components/luxtronik_v1/select/luxtronik_select.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include "luxtronik_select.h"
+
+
+namespace esphome::luxtronik_v1
+{
+    void LuxtronikSelect::control(const std::string &value)
+    {
+        auto index = index_of(value);
+        m_set_trigger.trigger(value, index.has_value() ? index.value() : 255);
+
+        publish_state(value);
+    }
+
+#ifdef USE_TEXT_SENSOR
+    void LuxtronikSelect::set_source_sensor(text_sensor::TextSensor* sensor)
+    {
+        m_source_sensor = sensor;
+
+        m_source_sensor->add_on_state_callback([this](std::string value)
+        {
+            publish_state(value);
+        });
+    }
+#endif
+}  // namespace esphome::luxtronik_v1

--- a/components/luxtronik_v1/select/luxtronik_select.h
+++ b/components/luxtronik_v1/select/luxtronik_select.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include "esphome/core/defines.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/select/select.h"
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
+
+namespace esphome::luxtronik_v1
+{
+    class LuxtronikSelect
+            : public select::Select
+    {
+    public:
+        LuxtronikSelect()
+            : select::Select()
+            , m_set_trigger()
+        {
+        }
+
+        Trigger<std::string, uint8_t>* get_set_trigger() { return &m_set_trigger; }
+
+#ifdef USE_SENSOR
+        void set_source_sensor(text_sensor::TextSensor* sensor);
+#endif
+
+    protected:
+        void control(const std::string &value) override;
+
+        Trigger<std::string, uint8_t> m_set_trigger;
+#ifdef USE_SENSOR
+        text_sensor::TextSensor* m_source_sensor;
+#endif
+    };
+}  // namespace esphome::luxtronik_v1

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -328,190 +328,6 @@ number:
       - luxtronik_v1.set_hot_water_set_temperature:
           id: luxtronik_heat_pump
           value: !lambda "return x;"
-  # number input for setting hour part of hot water off-time week start 1
-  - platform: template
-    id: target_hot_water_off_time_week_start_1_hour
-    name: Sperrzeit Brauchwarmwasser 1 Beginn Stunde
-    icon: mdi:alpha-h-box
-    unit_of_measurement: h
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 23
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_start_1);
-      if (!id(hot_water_off_times_week_edit_mode).state && cur->has_state())
-      {
-          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_start_1_hour).publish_state(x);"
-  # number input for setting minute part of hot water off-time week start 1
-  - platform: template
-    id: target_hot_water_off_time_week_start_1_minute
-    name: Sperrzeit Brauchwarmwasser 1 Beginn Minute
-    icon: mdi:alpha-m-box
-    unit_of_measurement: min
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 59
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_start_1);
-      if (!id(target_hot_water_off_time_week_start_1_minute).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_start_1_minute).publish_state(x);"
-  # number input for setting hour part of hot water off-time week end 1
-  - platform: template
-    id: target_hot_water_off_time_week_end_1_hour
-    name: Sperrzeit Brauchwarmwasser 1 Ende Stunde
-    icon: mdi:alpha-h-box
-    unit_of_measurement: h
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 23
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_end_1);
-      if (!id(target_hot_water_off_time_week_end_1_hour).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_end_1_hour).publish_state(x);"
-  # number input for setting minute part of hot water off-time week end 1
-  - platform: template
-    id: target_hot_water_off_time_week_end_1_minute
-    name: Sperrzeit Brauchwarmwasser 1 Ende Minute
-    icon: mdi:alpha-m-box
-    unit_of_measurement: min
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 59
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_end_1);
-      if (!id(target_hot_water_off_time_week_end_1_minute).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_end_1_minute).publish_state(x);"
-  # number input for setting hour part of hot water off-time week start 2
-  - platform: template
-    id: target_hot_water_off_time_week_start_2_hour
-    name: Sperrzeit Brauchwarmwasser 2 Beginn Stunde
-    icon: mdi:alpha-h-box
-    unit_of_measurement: h
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 23
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_start_2);
-      if (!id(target_hot_water_off_time_week_start_2_hour).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_start_2_hour).publish_state(x);"
-  # number input for setting minute part of hot water off-time week start 2
-  - platform: template
-    id: target_hot_water_off_time_week_start_2_minute
-    name: Sperrzeit Brauchwarmwasser 2 Beginn Minute
-    icon: mdi:alpha-m-box
-    unit_of_measurement: min
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 59
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_start_2);
-      if (!id(target_hot_water_off_time_week_start_2_minute).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_start_2_minute).publish_state(x);"
-  # number input for setting hour part of hot water off-time week end 2
-  - platform: template
-    id: target_hot_water_off_time_week_end_2_hour
-    name: Sperrzeit Brauchwarmwasser 2 Ende Stunde
-    icon: mdi:alpha-h-box
-    unit_of_measurement: h
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 23
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_end_2);
-      if (!id(target_hot_water_off_time_week_end_2_hour).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(0, cur->state.find(':')).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_end_2_hour).publish_state(x);"
-  # number input for setting minute part of hot water off-time week end 1
-  - platform: template
-    id: target_hot_water_off_time_week_end_2_minute
-    name: Sperrzeit Brauchwarmwasser 2 Ende Minute
-    icon: mdi:alpha-m-box
-    unit_of_measurement: min
-    entity_category: config
-    mode: box
-    min_value: 0
-    max_value: 59
-    step: 1
-    lambda: |-
-      auto cur = id(current_hot_water_off_time_week_end_2);
-      if (!id(target_hot_water_off_time_week_end_2_minute).has_state() && cur->has_state())
-      {
-          return atoi(cur->state.substr(cur->state.find(':') + 1).c_str());
-      }
-      else
-      {
-          return nullopt;
-      }
-    set_action:
-      - lambda: "id(target_hot_water_off_time_week_end_2_minute).publish_state(x);"
   # number input for setting return temperature offset from heat curcuit heating curve
   - platform: luxtronik_v1
     id: target_heating_curve_hc_return_offset
@@ -603,6 +419,32 @@ number:
     data_source: current_heating_curve_mc1_constant_flow
     edit_mode_switch: heating_curves_edit_mode
 
+datetime:
+  # number input for setting hot water off-time week start 1
+  - platform: luxtronik_v1
+    id: target_hot_water_off_time_week_start_1
+    name: Tägliche Sperrzeit Brauchwarmwasser 1 Beginn
+    data_source: current_hot_water_off_time_week_start_1
+    edit_mode_switch: hot_water_off_times_week_edit_mode
+  # number input for setting hot water off-time week end 1
+  - platform: luxtronik_v1
+    id: target_hot_water_off_time_week_end_1
+    name: Tägliche Sperrzeit Brauchwarmwasser 1 Ende
+    data_source: current_hot_water_off_time_week_end_1
+    edit_mode_switch: hot_water_off_times_week_edit_mode
+  # number input for setting hot water off-time week start 2
+  - platform: luxtronik_v1
+    id: target_hot_water_off_time_week_start_2
+    name: Tägliche Sperrzeit Brauchwarmwasser 2 Beginn
+    data_source: current_hot_water_off_time_week_start_2
+    edit_mode_switch: hot_water_off_times_week_edit_mode
+  # number input for setting hot water off-time week end 2
+  - platform: luxtronik_v1
+    id: target_hot_water_off_time_week_end_2
+    name: Tägliche Sperrzeit Brauchwarmwasser 2 Ende
+    data_source: current_hot_water_off_time_week_end_2
+    edit_mode_switch: hot_water_off_times_week_edit_mode
+
 select:
   # selection for heating mode
   - platform: luxtronik_v1
@@ -646,14 +488,14 @@ button:
     on_press:
       - luxtronik_v1.set_hot_water_off_times_week:
           id: luxtronik_heat_pump
-          start_1_hour: !lambda "return id(target_hot_water_off_time_week_start_1_hour).state;"
-          start_1_minute: !lambda "return id(target_hot_water_off_time_week_start_1_minute).state;"
-          end_1_hour: !lambda "return id(target_hot_water_off_time_week_end_1_hour).state;"
-          end_1_minute: !lambda "return id(target_hot_water_off_time_week_end_1_minute).state;"
-          start_2_hour: !lambda "return id(target_hot_water_off_time_week_start_2_hour).state;"
-          start_2_minute: !lambda "return id(target_hot_water_off_time_week_start_2_minute).state;"
-          end_2_hour: !lambda "return id(target_hot_water_off_time_week_end_2_hour).state;"
-          end_2_minute: !lambda "return id(target_hot_water_off_time_week_end_2_minute).state;"
+          start_1_hour: !lambda "return id(target_hot_water_off_time_week_start_1).hour;"
+          start_1_minute: !lambda "return id(target_hot_water_off_time_week_start_1).minute;"
+          end_1_hour: !lambda "return id(target_hot_water_off_time_week_end_1).hour;"
+          end_1_minute: !lambda "return id(target_hot_water_off_time_week_end_1).minute;"
+          start_2_hour: !lambda "return id(target_hot_water_off_time_week_start_2).hour;"
+          start_2_minute: !lambda "return id(target_hot_water_off_time_week_start_2).minute;"
+          end_2_hour: !lambda "return id(target_hot_water_off_time_week_end_2).hour;"
+          end_2_minute: !lambda "return id(target_hot_water_off_time_week_end_2).minute;"
       - switch.turn_off:
           id: hot_water_off_times_week_edit_mode
   # button for sending heating curves to Luxtronik heating control unit

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -317,25 +317,17 @@ text_sensor:
 
 number:
   # number input for setting hot water set temperature
-  - platform: template
-    id: target_hot_water_set_temperature
+  - platform: luxtronik_v1
     name: Soll-Temperatur Brauchwarmwasser
     icon: mdi:coolant-temperature
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: slider
     min_value: 30.0
     max_value: 65.0
-    step: 0.5
-    lambda: |-
-      if (id(current_hot_water_set_temperature).has_state()) { return id(current_hot_water_set_temperature).state; }
-      else { return nullopt; }
+    data_source: current_hot_water_set_temperature
     set_action:
       - luxtronik_v1.set_hot_water_set_temperature:
           id: luxtronik_heat_pump
           value: !lambda "return x;"
-      - lambda: "id(target_hot_water_set_temperature).publish_state(x);"
   # number input for setting hour part of hot water off-time week start 1
   - platform: template
     id: target_hot_water_off_time_week_start_1_hour
@@ -521,158 +513,95 @@ number:
     set_action:
       - lambda: "id(target_hot_water_off_time_week_end_2_minute).publish_state(x);"
   # number input for setting return temperature offset from heat curcuit heating curve
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_hc_return_offset
     name: Abweichung Rücklauf von Heizkurve
     icon: mdi:plus-minus-variant
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: slider
     min_value: -5.0
     max_value: 5.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_return_offset).has_state()) { return id(current_heating_curve_hc_return_offset).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_hc_return_offset).publish_state(x);"
+    data_source: current_heating_curve_hc_return_offset
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting heat curcuit heating curve endpoint
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_hc_endpoint
     name: Heizkurve Endpunkt
     icon: mdi:arrow-collapse-right
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: box
     min_value: 20.0
     max_value: 50.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_endpoint).has_state()) { return id(current_heating_curve_hc_endpoint).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_hc_endpoint).publish_state(x);"
+    data_source: current_heating_curve_hc_endpoint
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting heat curcuit heating curve parallel shift
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_hc_parallel_shift
     name: Heizkurve Parallelverschiebung
     icon: mdi:arrow-expand
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: box
     min_value: 0.0
     max_value: 40.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_parallel_shift).has_state()) { return id(current_heating_curve_hc_parallel_shift).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_hc_parallel_shift).publish_state(x);"
+    data_source: current_heating_curve_hc_parallel_shift
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting heat curcuit heating curve night setback
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_hc_night_setback
     name: Heizkurve Nachtabsenkung
     icon: mdi:moon-waning-crescent
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: slider
     min_value: -10.0
     max_value: 0.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_night_setback).has_state()) { return id(current_heating_curve_hc_night_setback).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_hc_night_setback).publish_state(x);"
+    data_source: current_heating_curve_hc_night_setback
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting heat curcuit constant return temperature
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_hc_constant_return
     name: Heizkurve Festwert Rücklauf
     icon: mdi:format-vertical-align-center
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: box
     min_value: 0.0
     max_value: 50.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_hc_constant_return).has_state()) { return id(current_heating_curve_hc_constant_return).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_hc_constant_return).publish_state(x);"
+    data_source: current_heating_curve_hc_constant_return
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting mixed curcuit 1 endpoint
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_mc1_endpoint
     name: Heizkurve Mischkreis 1 Endpunkt
     icon: mdi:arrow-collapse-right
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: box
     min_value: 20.0
     max_value: 50.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_endpoint).has_state()) { return id(current_heating_curve_mc1_endpoint).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_mc1_endpoint).publish_state(x);"
+    data_source: current_heating_curve_mc1_endpoint
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting mixed curcuit 1 parallel shift
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_mc1_parallel_shift
     name: Heizkurve Mischkreis 1 Parallelverschiebung
     icon: mdi:arrow-expand
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: box
     min_value: 0.0
     max_value: 40.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_parallel_shift).has_state()) { return id(current_heating_curve_mc1_parallel_shift).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_mc1_parallel_shift).publish_state(x);"
+    data_source: current_heating_curve_mc1_parallel_shift
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting mixed curcuit 1 night setback
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_mc1_night_setback
     name: Heizkurve Mischkreis 1 Nachtabsenkung
     icon: mdi:moon-waning-crescent
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: slider
     min_value: -10.0
     max_value: 0.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_night_setback).has_state()) { return id(current_heating_curve_mc1_night_setback).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_mc1_night_setback).publish_state(x);"
+    data_source: current_heating_curve_mc1_night_setback
+    edit_mode_switch: heating_curves_edit_mode
   # number input for setting mixed curcuit 1 constant flow temperature
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_curve_mc1_constant_flow
     name: Heizkurve Mischkreis 1 Festwert Vorlauf
     icon: mdi:format-vertical-align-center
-    unit_of_measurement: °C
-    device_class: temperature
-    entity_category: config
     mode: box
     min_value: 0.0
     max_value: 50.0
-    step: 0.5
-    lambda: |-
-      if (!id(heating_curves_edit_mode).state && id(current_heating_curve_mc1_constant_flow).has_state()) { return id(current_heating_curve_mc1_constant_flow).state; }
-      else { return nullopt; }
-    set_action:
-      - lambda: "id(target_heating_curve_mc1_constant_flow).publish_state(x);"
+    data_source: current_heating_curve_mc1_constant_flow
+    edit_mode_switch: heating_curves_edit_mode
 
 select:
   # selection for heating mode

--- a/example_config/luxtronik_lwc.yaml
+++ b/example_config/luxtronik_lwc.yaml
@@ -605,49 +605,37 @@ number:
 
 select:
   # selection for heating mode
-  - platform: template
+  - platform: luxtronik_v1
     id: target_heating_mode
     name: Betriebsart Heizung
-    icon: mdi:state-machine
-    entity_category: config
+    icon: mdi:radiator
     options:
       - Automatik
       - Zweiter Wärmeerzeuger
       - Party
       - Ferien
       - Aus
-    lambda: |-
-      if (id(current_heating_mode).has_state()) { return id(current_heating_mode).state; }
-      else { return nullopt; }
+    data_source: current_heating_mode
     set_action:
       - luxtronik_v1.set_heating_mode:
           id: luxtronik_heat_pump
-          mode: !lambda |-
-            auto idx = id(target_heating_mode).index_of(x);
-            return idx.has_value() ? idx.value() : 255;
-      - lambda: "id(target_heating_mode).publish_state(x);"
+          mode: !lambda "return i;"
   # selection for heating mode
-  - platform: template
+  - platform: luxtronik_v1
     id: target_hot_water_mode
     name: Betriebsart Brauchwarmwasser
     icon: mdi:water-boiler
-    entity_category: config
     options:
       - Automatik
       - Zweiter Wärmeerzeuger
       - Party
       - Ferien
       - Aus
-    lambda: |-
-      if (id(current_hot_water_mode).has_state()) { return id(current_hot_water_mode).state; }
-      else { return nullopt; }
+    data_source: current_hot_water_mode
     set_action:
       - luxtronik_v1.set_hot_water_mode:
           id: luxtronik_heat_pump
-          mode: !lambda |-
-            auto idx = id(target_hot_water_mode).index_of(x);
-            return idx.has_value() ? idx.value() : 255;
-      - lambda: "id(target_hot_water_mode).publish_state(x);"
+          mode: !lambda "return i;"
 
 button:
   # button for sending hot water off-times week to Luxtronik heating control unit


### PR DESCRIPTION
Adds specific number, select and time select components that can be used in the user interface to configure parameters of the Luxtronik heating control unit. These components have some advantages compared to the template variants as they have the capability to directly update from sensors and some of them support an edit mode switch to prevent overwriting the values during editing. Additionally, less lambda code is needed when using the Luxtronik variants.