### PR TITLE
Fix compilation errors with new ESPHome versions

### DIFF
--- a/components/luxtronik_v1/__init__.py
+++ b/components/luxtronik_v1/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Jens-Uwe Rossbach
+# Copyright (c) 2024-2026 Jens-Uwe Rossbach
 #
 # This code is licensed under the MIT License.
 #
@@ -122,7 +122,8 @@ async def to_code(config):
     cv.Schema(
     {
         cv.Required(CONF_ID): cv.use_id(Luxtronik)
-    }))
+    }),
+    synchronous = True)
 async def request_datasets_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     act = cg.new_Pvariable(action_id, template_arg, parent)
@@ -132,7 +133,8 @@ async def request_datasets_action_to_code(config, action_id, template_arg, args)
 @automation.register_action(
     "luxtronik_v1.set_heating_mode",
     SetOperationalModeAction,
-    SET_OPERATIONAL_MODE_SCHEMA)
+    SET_OPERATIONAL_MODE_SCHEMA,
+    synchronous = True)
 async def set_heating_mode_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     act = cg.new_Pvariable(action_id, template_arg, parent, TYPE_HEATING_MODE)
@@ -145,7 +147,8 @@ async def set_heating_mode_action_to_code(config, action_id, template_arg, args)
 @automation.register_action(
     "luxtronik_v1.set_hot_water_mode",
     SetOperationalModeAction,
-    SET_OPERATIONAL_MODE_SCHEMA)
+    SET_OPERATIONAL_MODE_SCHEMA,
+    synchronous = True)
 async def set_hot_water_mode_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     act = cg.new_Pvariable(action_id, template_arg, parent, TYPE_HOT_WATER_MODE)
@@ -162,7 +165,8 @@ async def set_hot_water_mode_action_to_code(config, action_id, template_arg, arg
     {
         cv.Required(CONF_ID): cv.use_id(Luxtronik),
         cv.Required(CONF_VALUE): cv.templatable(cv.float_range(min = 30.0, max = 65.0))
-    }))
+    }),
+    synchronous = True)
 async def set_hot_water_set_temperature_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     act = cg.new_Pvariable(action_id, template_arg, parent)
@@ -186,7 +190,8 @@ async def set_hot_water_set_temperature_action_to_code(config, action_id, templa
         cv.Required(CONF_START_2_MINUTE): cv.templatable(cv.int_range(min = 0, max = 59)),
         cv.Required(CONF_END_2_HOUR): cv.templatable(cv.int_range(min = 0, max = 23)),
         cv.Required(CONF_END_2_MINUTE): cv.templatable(cv.int_range(min = 0, max = 59))
-    }))
+    }),
+    synchronous = True)
 async def set_heating_curves_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     act = cg.new_Pvariable(action_id, template_arg, parent)
@@ -225,7 +230,8 @@ async def set_heating_curves_action_to_code(config, action_id, template_arg, arg
         cv.Optional(CONF_MC1_PARALLEL_SHIFT): cv.templatable(cv.positive_float),
         cv.Optional(CONF_MC1_NIGHT_SETBACK): cv.templatable(cv.float_range(max = 0.0)),
         cv.Optional(CONF_MC1_CONST_FLOW): cv.templatable(cv.positive_float)
-    }))
+    }),
+    synchronous = True)
 async def set_heating_curves_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     act = cg.new_Pvariable(action_id, template_arg, parent)

--- a/components/luxtronik_v1/automation.h
+++ b/components/luxtronik_v1/automation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Jens-Uwe Rossbach
+ * Copyright (c) 2025-2026 Jens-Uwe Rossbach
  *
  * This code is licensed under the MIT License.
  *
@@ -41,7 +41,7 @@ namespace esphome::luxtronik_v1
         {
         }
 
-        void play(Ts... x) override
+        void play(const Ts&... x) override
         {
             m_luxtronik->request_datasets();
         }
@@ -60,7 +60,7 @@ namespace esphome::luxtronik_v1
         {
         }
 
-        void play(Ts... x) override
+        void play(const Ts&... x) override
         {
             m_luxtronik->set_operational_mode(m_mode_type, m_operational_mode_value.value(x...));
         }
@@ -85,7 +85,7 @@ namespace esphome::luxtronik_v1
         {
         }
 
-        void play(Ts... x) override
+        void play(const Ts&... x) override
         {
             m_luxtronik->set_hot_water_set_temperature(m_set_temperature_value.value(x...));
         }
@@ -116,7 +116,7 @@ namespace esphome::luxtronik_v1
         {
         }
 
-        void play(Ts... x) override
+        void play(const Ts&... x) override
         {
             m_luxtronik->set_hot_water_off_times_week(
                             m_start_1_hour_value.value(x...),
@@ -198,7 +198,7 @@ namespace esphome::luxtronik_v1
         {
         }
 
-        void play(Ts... x) override
+        void play(const Ts&... x) override
         {
             Luxtronik::HeatingCurves heating_curves;
             heating_curves.hc_return_offset_avail = m_hc_return_offset_value.has_value();

--- a/components/luxtronik_v1/datetime/__init__.py
+++ b/components/luxtronik_v1/datetime/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Jens-Uwe Rossbach
+# Copyright (c) 2025-2026 Jens-Uwe Rossbach
 #
 # This code is licensed under the MIT License.
 #
@@ -27,7 +27,8 @@ import esphome.config_validation as cv
 from esphome            import automation
 from esphome.components import datetime, switch, text_sensor
 from esphome.const      import (
-    CONF_SET_ACTION
+    CONF_SET_ACTION,
+    ENTITY_CATEGORY_CONFIG
 )
 from ..                 import (
     luxtronik_ns,
@@ -37,19 +38,19 @@ from ..                 import (
 
 
 LuxtronikTime = luxtronik_ns.class_("LuxtronikTime", datetime.TimeEntity)
-EntityCategory = cg.global_ns.enum("esphome::EntityCategory")
 
 CONFIG_SCHEMA = datetime.time_schema(LuxtronikTime).extend(
 {
     cv.Optional(CONF_SET_ACTION): automation.validate_automation(single = True),
     cv.Optional(CONF_DATA_SOURCE): cv.use_id(text_sensor.TextSensor),
     cv.Optional(CONF_EDIT_MODE_SWITCH): cv.use_id(switch.Switch)
-})
+}).extend(cv.ENTITY_BASE_SCHEMA.extend({
+    cv.Optional("entity_category", default=ENTITY_CATEGORY_CONFIG): cv.entity_category,
+}))
 
 
 async def to_code(config):
     tim = await datetime.new_datetime(config)
-    cg.add(tim.set_entity_category(EntityCategory.ENTITY_CATEGORY_CONFIG))
 
     if CONF_DATA_SOURCE in config:
         sns = await cg.get_variable(config[CONF_DATA_SOURCE])

--- a/components/luxtronik_v1/luxtronik_sensor.cpp
+++ b/components/luxtronik_v1/luxtronik_sensor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Jens-Uwe Rossbach
+ * Copyright (c) 2024-2026 Jens-Uwe Rossbach
  *
  * This code is licensed under the MIT License.
  *
@@ -60,7 +60,7 @@ namespace esphome::luxtronik_v1
         if (m_sensor != nullptr)
         {
             m_task_handler.enqueue_task(std::bind(
-                                &text_sensor::TextSensor::publish_state,
+                                static_cast<void (text_sensor::TextSensor::*)(const std::string&)>(&text_sensor::TextSensor::publish_state),
                                 m_sensor, input_str));
         }
 #endif
@@ -72,7 +72,7 @@ namespace esphome::luxtronik_v1
         if (m_sensor != nullptr)
         {
             m_task_handler.enqueue_task(std::bind(
-                                &text_sensor::TextSensor::publish_state,
+                                static_cast<void (text_sensor::TextSensor::*)(const std::string&)>(&text_sensor::TextSensor::publish_state),
                                 m_sensor, input_str.substr(start, end - start)));
         }
 #endif
@@ -116,7 +116,7 @@ namespace esphome::luxtronik_v1
             }
 
             m_task_handler.enqueue_task(std::bind(
-                                &text_sensor::TextSensor::publish_state,
+                                static_cast<void (text_sensor::TextSensor::*)(const std::string&)>(&text_sensor::TextSensor::publish_state),
                                 m_sensor, std::move(state)));
         }
 #endif


### PR DESCRIPTION
Fixes compilation errors and warnings due to breaking changes introduced in ESPHome 2025.11.0, 2026.1.0 and 2026.3.0.

Resolves #52