### PR TITLE
Perform retries if requests are refused

### DIFF
--- a/components/luxtronik_v1/luxtronik.cpp
+++ b/components/luxtronik_v1/luxtronik.cpp
@@ -477,14 +477,20 @@ namespace esphome::luxtronik_v1
 
             m_timer.schedule(
                         std::chrono::milliseconds(m_response_timeout),
-                        [this]() { handle_timeout(); });
+                        [this]()
+                        {
+                            ESP_LOGW(
+                                TAG,
+                                "No response from Luxtronik within %u ms:  REQ %s",
+                                m_response_timeout,
+                                m_request_queue.front().c_str());
+                            retry_request();
+                        });
         }
     }
 
-    void Luxtronik::handle_timeout()
+    void Luxtronik::retry_request()
     {
-        ESP_LOGW(TAG, "No response from Luxtronik within %u ms:  REQ %s", m_response_timeout, m_request_queue.front().c_str());
-
         if (++m_retry_count > m_max_retries)
         {
             ESP_LOGW(TAG, "Maximum number of retries reached, skipping data set");
@@ -655,8 +661,8 @@ namespace esphome::luxtronik_v1
             std::string cmd = response.substr(start, end - start);
             ESP_LOGW(TAG, "Request refused:  REQ %s", cmd.c_str());
 
-            m_lost_response = true;
-            next_dataset();
+            // possibly try again
+            retry_request();
         }
         else if (starts_with(response, TYPE_NACK_779))
         {

--- a/components/luxtronik_v1/luxtronik.h
+++ b/components/luxtronik_v1/luxtronik.h
@@ -215,7 +215,7 @@ namespace esphome::luxtronik_v1
         void parse_heating_mode(const std::string& response, bool update_sensors = true);
         void parse_hot_water_config(const std::string& response, bool update_sensors = true);
         void parse_hot_water_mode(const std::string& response, bool update_sensors = true);
-        void handle_timeout();
+        void retry_request();
         void clear_uart_buffer();
         void parse_slot(const std::string& slot, StringSensor& sensor_code, StringSensor& sensor_time);
 


### PR DESCRIPTION
When a request has been refused by the heating control unit, the same kind of retries as in the timeout case are performed to improve robustness against data loss.